### PR TITLE
feat: プレイの振り返り機能を追加

### DIFF
--- a/src/app/play/[sessionId]/page.tsx
+++ b/src/app/play/[sessionId]/page.tsx
@@ -18,6 +18,7 @@ import LoadingSpinner from "@/components/shared/LoadingSpinner";
 import { ACTION_DISPLAY_MAP } from "@/constants/poker";
 import { STREET_LABELS } from "@/constants/ui";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
+import PlayReview from "@/components/play/PlayReview";
 
 // --- ストリート進行順 ---
 const STREET_ORDER: readonly Street[] = ["preflop", "flop", "turn", "river"];
@@ -42,6 +43,7 @@ type GamePhase =
   | { step: "turn-complete"; playerIndex: number; street: Street }
   | { step: "dealer-turn"; street: Street }
   | { step: "hand-complete" }
+  | { step: "review" }
   | { step: "diagnosing" }
   | { step: "complete" };
 
@@ -860,23 +862,32 @@ export default function PlayPage() {
             ) : (
               <button
                 type="button"
-                onClick={runDiagnosis}
+                onClick={() => setPhase({ step: "review" })}
                 className="w-full rounded-lg bg-secondary px-6 py-4 text-lg font-bold text-white transition-all hover:bg-purple-500"
               >
-                全ハンド終了！診断を実行する
+                全ハンド終了！プレイを振り返る
               </button>
             )}
 
             {handCount < totalHands && handCount >= 1 && (
               <button
                 type="button"
-                onClick={runDiagnosis}
+                onClick={() => setPhase({ step: "review" })}
                 className="text-sm text-gray-400 underline transition-colors hover:text-gray-200"
               >
-                ここまでのデータで診断する
+                ここまでのプレイを振り返る
               </button>
             )}
           </div>
+        )}
+
+        {/* ========== プレイ振り返り ========== */}
+        {phase.step === "review" && session && (
+          <PlayReview
+            hands={session.hands}
+            players={players}
+            onContinue={runDiagnosis}
+          />
         )}
 
         {/* ========== 診断中 ========== */}

--- a/src/app/result/[sessionId]/[playerId]/page.tsx
+++ b/src/app/result/[sessionId]/[playerId]/page.tsx
@@ -8,10 +8,12 @@ import DiagnosisCard from "@/components/result/DiagnosisCard";
 import RadarChartDisplay from "@/components/result/RadarChartDisplay";
 import StatsSummary from "@/components/result/StatsSummary";
 import AdviceSection from "@/components/result/AdviceSection";
+import PlayerPlayReview from "@/components/result/PlayerPlayReview";
 
 export default function ResultPage() {
   const params = useParams<{ sessionId: string; playerId: string }>();
   const [result, setResult] = useState<DiagnosisResult | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,6 +33,7 @@ export default function ResultPage() {
           throw new Error("診断結果が見つかりません");
         }
         setResult(diagnosis);
+        setSession(json.data);
       } catch (err) {
         setError(err instanceof Error ? err.message : "予期しないエラーが発生しました");
       } finally {
@@ -86,6 +89,15 @@ export default function ResultPage() {
 
         {/* 統計サマリー */}
         <StatsSummary stats={result.stats} />
+
+        {/* プレイの振り返り */}
+        {session && (
+          <PlayerPlayReview
+            playerId={params.playerId}
+            hands={session.hands}
+            players={session.players}
+          />
+        )}
 
         {/* AIアドバイス */}
         <AdviceSection advice={result.advice} />

--- a/src/components/play/PlayReview.tsx
+++ b/src/components/play/PlayReview.tsx
@@ -1,0 +1,265 @@
+import type { Hand, Player, Action, Street } from "@/types";
+import { STREETS } from "@/types";
+import PlayingCard from "@/components/shared/PlayingCard";
+import { ACTION_DISPLAY_MAP } from "@/constants/poker";
+import { STREET_LABELS } from "@/constants/ui";
+
+type PlayReviewProps = {
+  readonly hands: readonly Hand[];
+  readonly players: readonly Player[];
+  readonly onContinue: () => void;
+};
+
+// ストリートごとのコミュニティカード枚数（累計）
+const COMMUNITY_CARD_CUMULATIVE: Readonly<Record<Street, number>> = {
+  preflop: 0,
+  flop: 3,
+  turn: 4,
+  river: 5,
+};
+
+// アクションに応じたスタイルクラス
+const ACTION_STYLE: Readonly<Record<Action["type"], string>> = {
+  fold: "text-gray-400",
+  check: "text-gray-300",
+  call: "text-poker-green",
+  raise: "text-poker-gold font-semibold",
+};
+
+// プレイヤーのアクションパターンに対する振り返りコメントを生成
+function getHandInsight(
+  playerActions: readonly Action[],
+  playerName: string,
+): string | null {
+  const preflopActions = playerActions.filter((a) => a.street === "preflop");
+  const postflopActions = playerActions.filter((a) => a.street !== "preflop");
+  const hasFolded = playerActions.some((a) => a.type === "fold");
+  const raiseCount = playerActions.filter((a) => a.type === "raise").length;
+  const callCount = playerActions.filter((a) => a.type === "call").length;
+
+  // プリフロップでフォールド
+  const foldedPreflop = preflopActions.some((a) => a.type === "fold");
+  if (foldedPreflop) {
+    return `${playerName}さんはプリフロップで降りました。慎重な判断ですが、参加しないとチャンスも逃します`;
+  }
+
+  // レイズ多め（2回以上）
+  if (raiseCount >= 2) {
+    return `${playerName}さんは積極的にレイズしました。主導権を握るプレイスタイルです`;
+  }
+
+  // フロップ以降でフォールド
+  if (hasFolded && postflopActions.some((a) => a.type === "fold")) {
+    const foldStreet = playerActions.find((a) => a.type === "fold")?.street;
+    if (foldStreet && foldStreet !== "preflop") {
+      return `${playerName}さんは${STREET_LABELS[foldStreet]}で降りました。損切りの判断が見られます`;
+    }
+  }
+
+  // コールばかり（受動的）
+  if (callCount >= 2 && raiseCount === 0) {
+    return `${playerName}さんはコール中心のプレイでした。受動的なスタイルは相手に主導権を渡しやすくなります`;
+  }
+
+  // リバーまで残った
+  const reachedRiver = !hasFolded;
+  if (reachedRiver && playerActions.length > 0) {
+    return `${playerName}さんは最後まで勝負しました。粘り強いプレイです`;
+  }
+
+  return null;
+}
+
+// ストリートに対応するコミュニティカードのスライスを返す
+function getCommunityCardsForStreet(
+  hand: Hand,
+  street: Street,
+): readonly typeof hand.communityCards[number][] {
+  const count = COMMUNITY_CARD_CUMULATIVE[street];
+  return hand.communityCards.slice(0, count);
+}
+
+export default function PlayReview({
+  hands,
+  players,
+  onContinue,
+}: PlayReviewProps) {
+  const completedHands = hands.filter((h) => h.isComplete);
+  const playerMap = new Map(players.map((p) => [p.id, p]));
+
+  return (
+    <div className="flex w-full max-w-lg flex-col gap-6">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold text-white">プレイの振り返り</h2>
+        <p className="mt-1 text-sm text-gray-400">
+          {completedHands.length}ハンドのプレイラインを確認しましょう
+        </p>
+      </div>
+
+      {/* ハンドごとの振り返り */}
+      <div className="flex flex-col gap-5">
+        {completedHands.map((hand) => (
+          <HandReviewCard
+            key={hand.id}
+            hand={hand}
+            playerMap={playerMap}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={onContinue}
+        className="w-full rounded-lg bg-secondary px-6 py-4 text-lg font-bold text-white transition-all hover:bg-purple-500"
+      >
+        診断を実行する
+      </button>
+    </div>
+  );
+}
+
+// --- ハンドごとのレビューカード ---
+
+type HandReviewCardProps = {
+  readonly hand: Hand;
+  readonly playerMap: ReadonlyMap<string, Player>;
+};
+
+function HandReviewCard({ hand, playerMap }: HandReviewCardProps) {
+  // このハンドに含まれるストリートを抽出（アクションがあるストリートのみ）
+  const activeStreets = STREETS.filter((s) =>
+    hand.actions.some((a) => a.street === s),
+  );
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+      {/* ハンドヘッダー */}
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-base font-bold text-poker-gold">
+          Hand {hand.handNumber}
+        </h3>
+        {hand.communityCards.length > 0 && (
+          <div className="flex gap-1">
+            {hand.communityCards.map((card, i) => (
+              <PlayingCard
+                key={`${card.suit}-${card.rank}-${i}`}
+                card={card}
+                size="sm"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ストリートごとのアクション */}
+      <div className="flex flex-col gap-3">
+        {activeStreets.map((street) => {
+          const streetActions = hand.actions
+            .filter((a) => a.street === street)
+            .sort((a, b) => a.order - b.order);
+          const communityCards = getCommunityCardsForStreet(hand, street);
+
+          return (
+            <div key={street}>
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-xs font-medium text-gray-400">
+                  {STREET_LABELS[street]}
+                </span>
+                {street !== "preflop" && communityCards.length > 0 && (
+                  <div className="flex gap-0.5">
+                    {communityCards.map((card, i) => (
+                      <PlayingCard
+                        key={`cc-${street}-${card.suit}-${card.rank}-${i}`}
+                        card={card}
+                        size="sm"
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col gap-0.5 pl-3">
+                {streetActions.map((action) => (
+                  <ActionLine
+                    key={`${action.playerId}-${action.order}`}
+                    action={action}
+                    playerName={
+                      playerMap.get(action.playerId)?.name ?? "不明"
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* プレイヤーごとの振り返りコメント */}
+      <PlayerInsights hand={hand} playerMap={playerMap} />
+    </div>
+  );
+}
+
+// --- アクション1行表示 ---
+
+type ActionLineProps = {
+  readonly action: Action;
+  readonly playerName: string;
+};
+
+function ActionLine({ action, playerName }: ActionLineProps) {
+  const style = ACTION_STYLE[action.type];
+  const amountText =
+    action.type === "raise" && action.amount !== null
+      ? ` (${action.amount})`
+      : "";
+
+  return (
+    <p className={`text-sm ${style}`}>
+      <span className="text-gray-300">{playerName}</span>{" "}
+      {ACTION_DISPLAY_MAP[action.type]}
+      {amountText}
+    </p>
+  );
+}
+
+// --- プレイヤーごとの振り返りコメント ---
+
+type PlayerInsightsProps = {
+  readonly hand: Hand;
+  readonly playerMap: ReadonlyMap<string, Player>;
+};
+
+function PlayerInsights({ hand, playerMap }: PlayerInsightsProps) {
+  // ハンドに参加したプレイヤーIDの一意リスト（アクション順）
+  const playerIds = [
+    ...new Set(hand.actions.map((a) => a.playerId)),
+  ];
+
+  const insights = playerIds
+    .map((playerId) => {
+      const player = playerMap.get(playerId);
+      if (!player) return null;
+      const playerActions = hand.actions.filter(
+        (a) => a.playerId === playerId,
+      );
+      const insight = getHandInsight(playerActions, player.name);
+      return insight ? { playerId, insight } : null;
+    })
+    .filter(
+      (item): item is { playerId: string; insight: string } => item !== null,
+    );
+
+  if (insights.length === 0) return null;
+
+  return (
+    <div className="mt-3 border-t border-white/5 pt-3">
+      <div className="flex flex-col gap-1.5">
+        {insights.map(({ playerId, insight }) => (
+          <p key={playerId} className="text-xs leading-relaxed text-gray-400">
+            💡 {insight}
+          </p>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 診断前にプレイライン全体を振り返れる「レビュー画面」を追加（`hand-complete` → `review` → `diagnosing`）
- 診断結果ページに個別プレイヤーの振り返りセクションを追加（統計サマリーとAIアドバイスの間に配置）
- ストリートごとのアクション表示、カード表示、視覚的ハイライト（レイズ=ゴールド、フォールド=グレー）、教育的インサイトを含む

## Changes
- `src/components/play/PlayReview.tsx` — 診断前の全体プレイ振り返りコンポーネント（新規）
- `src/components/result/PlayerPlayReview.tsx` — 診断結果ページの個別プレイヤー振り返りコンポーネント（新規）
- `src/app/play/[sessionId]/page.tsx` — GamePhaseに`review`ステップを追加、遷移フロー更新
- `src/app/result/[sessionId]/[playerId]/page.tsx` — Session全体をステートに保持、PlayerPlayReviewを挿入

## Test plan
- [ ] ゲームプレイ後、「プレイを振り返る」ボタンで全ハンドのレビューが表示されること
- [ ] レビュー画面から「診断を実行する」で正常に診断へ遷移すること
- [ ] 途中診断（「ここまでのプレイを振り返る」）でもレビュー画面が表示されること
- [ ] 診断結果ページで個別プレイヤーのプレイ振り返りが表示されること
- [ ] 対象プレイヤーのアクションが黄色背景でハイライトされること
- [ ] ホールカード・コミュニティカードが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)