### PR TITLE
fix: DiagnosisCardで古い診断データ表示時のランタイムエラーを修正

### DIFF
--- a/src/components/result/DiagnosisCard.tsx
+++ b/src/components/result/DiagnosisCard.tsx
@@ -4,8 +4,8 @@ type DiagnosisCardProps = {
   readonly pokerStyle: PokerStyle;
   readonly businessType: string;
   readonly businessTypeDescription: string;
-  readonly strengths: readonly string[];
-  readonly growthPotentials: readonly string[];
+  readonly strengths?: readonly string[];
+  readonly growthPotentials?: readonly string[];
 };
 
 const styleConfig: Record<PokerStyle, {
@@ -49,8 +49,8 @@ export default function DiagnosisCard({
   pokerStyle,
   businessType,
   businessTypeDescription,
-  strengths,
-  growthPotentials,
+  strengths = [],
+  growthPotentials = [],
 }: DiagnosisCardProps) {
   const config = styleConfig[pokerStyle];
 

--- a/src/types/diagnosis.ts
+++ b/src/types/diagnosis.ts
@@ -27,7 +27,7 @@ export type DiagnosisResult = {
   readonly axes: readonly DiagnosisAxis[];
   readonly stats: PokerStats;
   readonly advice: string;
-  readonly strengths: readonly string[];
-  readonly growthPotentials: readonly string[];
+  readonly strengths?: readonly string[];
+  readonly growthPotentials?: readonly string[];
   readonly createdAt: string;
 };


### PR DESCRIPTION
## Summary
- Firestoreに保存された古い診断データに `strengths` / `growthPotentials` フィールドが存在しない場合、`undefined.map()` で TypeError が発生していた問題を修正
- `DiagnosisResult` 型の該当フィールドをオプショナルに変更し、`DiagnosisCard` コンポーネントでデフォルト値 `[]` を設定

## Test plan
- [ ] 古い診断データ（strengths/growthPotentialsなし）のセッション詳細ページが正常表示されること
- [ ] 新しい診断データ（strengths/growthPotentialsあり）のセッション詳細ページが正常表示されること
- [ ] 個人レポートページ、結果ページでも同様にエラーが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)