### PR TITLE
fix: ホールカード入力時の重複カード選択防止

### DIFF
--- a/e2e/play-card-dedup.spec.ts
+++ b/e2e/play-card-dedup.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "./fixtures/test-fixtures";
+import { setupApiMocks } from "./fixtures/api-mocker";
+import { createTwoPlayerSession } from "./fixtures/mock-data";
+import { selectCard } from "./helpers/card-selector";
+
+test.describe("カード重複防止", () => {
+  /**
+   * 共通セットアップ:
+   * 2人プレイ → hand-start → BTN選択 → カードを配る → Bob(index 1)のplayer-intro → card-input
+   * Bob が ♠A, ♥K を選択して確定 → action(チェック) → turn-complete
+   * → Alice(index 0)のplayer-intro → card-input まで進める
+   */
+  async function setupToSecondPlayerCardInput(page: import("@playwright/test").Page) {
+    const { session } = createTwoPlayerSession();
+    await setupApiMocks(page, session);
+    await page.goto(`/play/${session.id}`);
+
+    // hand-start: BTN選択 → カードを配る
+    await expect(page.getByText("ゲーム開始")).toBeVisible();
+    await page.getByText("1. Alice").click();
+    await page.getByRole("button", { name: "カードを配る" }).click();
+
+    // Bob の player-intro
+    await expect(page.getByText("Bobさん")).toBeVisible();
+    await page.getByRole("button", { name: "OK、準備できました" }).click();
+
+    // Bob の card-input: ♠A, ♥K を選択
+    await expect(page.getByText("Bobさんのカード")).toBeVisible();
+    await selectCard(page, "spade", "A");
+    await selectCard(page, "heart", "K");
+    await page.getByRole("button", { name: /カードを確定/ }).click();
+
+    // Bob の action-select: チェック
+    await expect(page.getByText("アクションを選択してください")).toBeVisible();
+    await page.getByRole("button", { name: "チェック" }).click();
+
+    // turn-complete → Alice へ
+    await expect(page.getByText("記録完了！")).toBeVisible();
+    await page.getByRole("button", { name: "次の人の準備ができました" }).click();
+
+    // Alice の player-intro
+    await expect(page.getByText("Aliceさん")).toBeVisible();
+    await page.getByRole("button", { name: "OK、準備できました" }).click();
+
+    // Alice の card-input フェーズ
+    await expect(page.getByText("Aliceさんのカード")).toBeVisible();
+  }
+
+  test("前のプレイヤーが使用したカードはタップしても選択されない", async ({ page }) => {
+    await setupToSecondPlayerCardInput(page);
+
+    // Bob が使った ♠A をタップ → 選択されないことを検証
+    await selectCard(page, "spade", "A");
+
+    // まだ「1枚目を選択」の状態のまま = 選択されていない
+    await expect(page.getByText("配られたカードを選択してください")).toBeVisible();
+  });
+
+  test("前のプレイヤーが使用したカード（2枚目）もタップしても選択されない", async ({ page }) => {
+    await setupToSecondPlayerCardInput(page);
+
+    // Bob が使った ♥K をタップ → 選択されないことを検証
+    await selectCard(page, "heart", "K");
+
+    // まだ「1枚目を選択」の状態のまま
+    await expect(page.getByText("配られたカードを選択してください")).toBeVisible();
+  });
+
+  test("使用済みでないカードは正常に選択できる", async ({ page }) => {
+    await setupToSecondPlayerCardInput(page);
+
+    // 未使用の ♦Q, ♣J を選択 → 正常に選択できる
+    await selectCard(page, "diamond", "Q");
+    await selectCard(page, "club", "J");
+
+    // 2枚選択完了 → 確定ボタンが表示される
+    await expect(page.getByRole("button", { name: /カードを確定/ })).toBeVisible();
+  });
+
+  test("使用済みカードをタップ後に未使用カードを選べる", async ({ page }) => {
+    await setupToSecondPlayerCardInput(page);
+
+    // 使用済み ♠A をタップ（反応なし）
+    await selectCard(page, "spade", "A");
+    await expect(page.getByText("配られたカードを選択してください")).toBeVisible();
+
+    // 未使用の ♦10 を選択 → 1枚目として選択される
+    await selectCard(page, "diamond", "10");
+
+    // 使用済み ♥K をタップ（反応なし）
+    await selectCard(page, "heart", "K");
+
+    // 未使用の ♣9 を選択 → 2枚目として選択される
+    await selectCard(page, "club", "9");
+
+    // 2枚選択完了
+    await expect(page.getByRole("button", { name: /カードを確定/ })).toBeVisible();
+  });
+});

--- a/e2e/play-card-dedup.spec.ts
+++ b/e2e/play-card-dedup.spec.ts
@@ -2,13 +2,14 @@ import { test, expect } from "./fixtures/test-fixtures";
 import { setupApiMocks } from "./fixtures/api-mocker";
 import { createTwoPlayerSession } from "./fixtures/mock-data";
 import { selectCard } from "./helpers/card-selector";
+import { playPreflopTurn, goThroughPlayerIntro } from "./helpers/play-flow";
 
 test.describe("カード重複防止", () => {
   /**
    * 共通セットアップ:
-   * 2人プレイ → hand-start → BTN選択 → カードを配る → Bob(index 1)のplayer-intro → card-input
-   * Bob が ♠A, ♥K を選択して確定 → action(チェック) → turn-complete
-   * → Alice(index 0)のplayer-intro → card-input まで進める
+   * 2人プレイ → hand-start → BTN選択 → カードを配る
+   * → Bob のプリフロップターン(♠A, ♥K, チェック)
+   * → Alice のcard-input フェーズまで進める
    */
   async function setupToSecondPlayerCardInput(page: import("@playwright/test").Page) {
     const { session } = createTwoPlayerSession();
@@ -20,29 +21,16 @@ test.describe("カード重複防止", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // Bob の player-intro
-    await expect(page.getByText("Bobさん")).toBeVisible();
-    await page.getByRole("button", { name: "OK、準備できました" }).click();
+    // Bob のプリフロップターン全体（intro → card-input → action → turn-complete）
+    await playPreflopTurn(
+      page, "Bob",
+      { suit: "spade", rank: "A" },
+      { suit: "heart", rank: "K" },
+      "チェック",
+    );
 
-    // Bob の card-input: ♠A, ♥K を選択
-    await expect(page.getByText("Bobさんのカード")).toBeVisible();
-    await selectCard(page, "spade", "A");
-    await selectCard(page, "heart", "K");
-    await page.getByRole("button", { name: /カードを確定/ }).click();
-
-    // Bob の action-select: チェック
-    await expect(page.getByText("アクションを選択してください")).toBeVisible();
-    await page.getByRole("button", { name: "チェック" }).click();
-
-    // turn-complete → Alice へ
-    await expect(page.getByText("記録完了！")).toBeVisible();
-    await page.getByRole("button", { name: "次の人の準備ができました" }).click();
-
-    // Alice の player-intro
-    await expect(page.getByText("Aliceさん")).toBeVisible();
-    await page.getByRole("button", { name: "OK、準備できました" }).click();
-
-    // Alice の card-input フェーズ
+    // Alice の player-intro → card-input フェーズへ
+    await goThroughPlayerIntro(page, "Alice");
     await expect(page.getByText("Aliceさんのカード")).toBeVisible();
   }
 

--- a/src/app/api/sessions/[sessionId]/hands/[handId]/hole-cards/route.ts
+++ b/src/app/api/sessions/[sessionId]/hands/[handId]/hole-cards/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { getSession, getHand, setHoleCards } from "@/lib/store";
 import { successResponse, errorResponse } from "@/lib/response";
 import { MESSAGES } from "@/constants/ui";
-import { isValidCard, isCardAvailableOnBoard } from "@/lib/validators";
+import { isValidCard, isCardAvailableInHand } from "@/lib/validators";
 import type { SetHoleCardsRequest } from "@/types";
 
 type RouteParams = { params: Promise<{ sessionId: string; handId: string }> };
@@ -40,7 +40,7 @@ export const PUT = async (request: NextRequest, { params }: RouteParams) => {
       if (!isValidCard(card)) {
         return errorResponse(MESSAGES.invalidCard);
       }
-      if (!isCardAvailableOnBoard(card, hand)) {
+      if (!isCardAvailableInHand(card, hand)) {
         return errorResponse(MESSAGES.cardAlreadyUsed);
       }
     }

--- a/src/app/play/[sessionId]/page.tsx
+++ b/src/app/play/[sessionId]/page.tsx
@@ -130,7 +130,8 @@ export default function PlayPage() {
     return session.hands.find((h) => h.id === currentHandId);
   }, [session, currentHandId]);
 
-  // ディーラー用: 全使用済みカード（他プレイヤーのホールカード含む）
+  // 全使用済みカード（全プレイヤーのホールカード + コミュニティカード）
+  // プレイヤーのcard-inputおよびディーラーターンで使用
   const allUsedCards: readonly Card[] = useMemo(() => {
     if (!currentHand) return [];
     const cards: Card[] = [];

--- a/src/app/play/[sessionId]/page.tsx
+++ b/src/app/play/[sessionId]/page.tsx
@@ -897,11 +897,11 @@ export default function PlayPage() {
                 : "カードをタップすると取り消せます"}
             </p>
 
-            {/* カードセレクター - プレイヤーには自分の選択中カードのみdisable */}
+            {/* カードセレクター - 他プレイヤーの使用済みカード + 自分の選択中カードをdisable */}
             {selectedCards.length < 2 && (
               <CardSelector
                 onSelect={handleCardSelect}
-                disabledCards={selectedCards}
+                disabledCards={[...allUsedCards, ...selectedCards]}
               />
             )}
 


### PR DESCRIPTION
## Summary
- プレイヤーのカード入力時、他プレイヤーが既に入力したホールカードをタップしても反応しないように変更（見た目変化なし）
- API側のバリデーションを`isCardAvailableOnBoard`→`isCardAvailableInHand`に強化し、全ホールカード+コミュニティカードとの重複チェックを実施
- カード重複防止のE2Eテスト4件を追加（既存play-flowヘルパーを活用）

## Test plan
- [x] `npx playwright test e2e/play-card-dedup.spec.ts` — 4/4 passed
- [x] `npm run build` — ビルド成功
- [x] 手動確認: 2人以上でプレイし、先のプレイヤーが選んだカードが後のプレイヤーで選択不可になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)