### PR TITLE
fix: プリフロップの最初のアクションをUTG（SB/BBの次）から開始 (#30)

### DIFF
--- a/e2e/play-button-rotation.spec.ts
+++ b/e2e/play-button-rotation.spec.ts
@@ -12,7 +12,7 @@ import {
 
 test.describe("ボタンポジションのローテーション", () => {
   test.describe("2人プレイヤー", () => {
-    test("Hand 1: BTN=Alice → Bobが最初に行動", async ({ page }) => {
+    test("Hand 1: BTN=Alice → Aliceが最初に行動（ヘッズアップ）", async ({ page }) => {
       const { session } = createTwoPlayerSession();
       await setupApiMocks(page, session);
       await page.goto(`/play/${session.id}`);
@@ -25,12 +25,12 @@ test.describe("ボタンポジションのローテーション", () => {
 
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Bobが最初に行動（BTNの次）
-      await expect(page.getByText("Bobさん")).toBeVisible();
+      // ヘッズアップ プリフロップ: BTN(=SB) が最初に行動
+      await expect(page.getByText("Aliceさん")).toBeVisible();
       await expect(page.getByText("あなたの番です")).toBeVisible();
     });
 
-    test("Hand 2: BTN=Bob → Aliceが最初に行動", async ({ page }) => {
+    test("Hand 2: BTN=Bob → Bobが最初に行動（ヘッズアップ）", async ({ page }) => {
       test.slow();
       const { session } = createTwoPlayerSession();
       await setupApiMocks(page, session);
@@ -42,9 +42,9 @@ test.describe("ボタンポジションのローテーション", () => {
       await page.getByText("1. Alice").click();
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Bob → Alice (preflop)
-      await goThroughPlayerIntro(page, "Bob");
-      await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+      // ヘッズアップ プリフロップ: Alice(BTN) → Bob
+      await goThroughPlayerIntro(page, "Alice");
+      await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
       await chooseAction(page, "フォールド");
       await proceedFromTurnComplete(page);
 
@@ -60,14 +60,14 @@ test.describe("ボタンポジションのローテーション", () => {
 
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Aliceが最初に行動（BTNの次）
-      await expect(page.getByText("Aliceさん")).toBeVisible();
+      // ヘッズアップ プリフロップ: BTN(Bob)が最初に行動
+      await expect(page.getByText("Bobさん")).toBeVisible();
       await expect(page.getByText("あなたの番です")).toBeVisible();
     });
   });
 
   test.describe("3人プレイヤー", () => {
-    test("Hand 1: BTN=Alice → Bobが最初に行動、3人全員が順番に行動", async ({ page }) => {
+    test("Hand 1: BTN=Alice → プリフロップはAlice(UTG=BTN)から開始、ポストフロップはBob(SB)から", async ({ page }) => {
       test.slow();
       const { session } = createThreePlayerSession();
       await setupApiMocks(page, session);
@@ -82,7 +82,12 @@ test.describe("ボタンポジションのローテーション", () => {
 
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Bob(index 1) → Charlie(index 2) → Alice(index 0) の順
+      // プリフロップ: Alice(BTN=UTG) → Bob(SB) → Charlie(BB) の順
+      await goThroughPlayerIntro(page, "Alice");
+      await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
+      await chooseAction(page, "チェック");
+      await proceedFromTurnComplete(page);
+
       await goThroughPlayerIntro(page, "Bob");
       await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
       await chooseAction(page, "チェック");
@@ -90,11 +95,6 @@ test.describe("ボタンポジションのローテーション", () => {
 
       await goThroughPlayerIntro(page, "Charlie");
       await inputHoleCards(page, { suit: "heart", rank: "10" }, { suit: "spade", rank: "9" });
-      await chooseAction(page, "チェック");
-      await proceedFromTurnComplete(page);
-
-      await goThroughPlayerIntro(page, "Alice");
-      await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
       await chooseAction(page, "チェック");
       await proceedFromTurnComplete(page);
 
@@ -110,7 +110,7 @@ test.describe("ボタンポジションのローテーション", () => {
         "フロップ",
       );
 
-      // ポストフロップもBob → Charlie → Aliceの順
+      // ポストフロップは Bob(SB) → Charlie(BB) → Alice(BTN) の順
       await playPostflopTurn(page, "Bob", "チェック");
       await playPostflopTurn(page, "Charlie", "チェック");
       await playPostflopTurn(page, "Alice", "チェック");
@@ -131,14 +131,14 @@ test.describe("ボタンポジションのローテーション", () => {
       await page.getByText("1. Alice").click();
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Bob → Charlie → Alice (preflop) — Bobがfoldしてすぐ終了
-      await goThroughPlayerIntro(page, "Bob");
-      await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+      // プリフロップ: Alice(BTN=UTG) → Bob → Charlie — 全員foldしてすぐ終了
+      await goThroughPlayerIntro(page, "Alice");
+      await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
       await chooseAction(page, "フォールド");
       await proceedFromTurnComplete(page);
 
-      await goThroughPlayerIntro(page, "Charlie");
-      await inputHoleCards(page, { suit: "heart", rank: "10" }, { suit: "spade", rank: "9" });
+      await goThroughPlayerIntro(page, "Bob");
+      await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
       await chooseAction(page, "フォールド");
       await proceedFromTurnComplete(page);
 
@@ -155,8 +155,8 @@ test.describe("ボタンポジションのローテーション", () => {
 
       await page.getByRole("button", { name: "カードを配る" }).click();
 
-      // Charlie(index 2)が最初に行動（BTN=Bob(index 1)の次）
-      await expect(page.getByText("Charlieさん")).toBeVisible();
+      // 3人プレイヤーではUTG=BTN自身、Bob(BTN)が最初に行動
+      await expect(page.getByText("Bobさん")).toBeVisible();
       await expect(page.getByText("あなたの番です")).toBeVisible();
     });
   });
@@ -173,14 +173,14 @@ test.describe("ボタンポジションのローテーション", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // プリフロップ: Bob → Alice
-    await goThroughPlayerIntro(page, "Bob");
-    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+    // ヘッズアップ プリフロップ: Alice(BTN=SB) → Bob(BB)
+    await goThroughPlayerIntro(page, "Alice");
+    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 
-    await goThroughPlayerIntro(page, "Alice");
-    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
+    await goThroughPlayerIntro(page, "Bob");
+    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 

--- a/e2e/play-button-selection.spec.ts
+++ b/e2e/play-button-selection.spec.ts
@@ -67,8 +67,8 @@ test.describe("ボタンプレイヤー選択（初回ハンド）", () => {
     await page.getByText("2. Bob").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // BTN=Bob → Aliceが最初に行動
-    await expect(page.getByText("Aliceさん")).toBeVisible();
+    // ヘッズアップ プリフロップ: BTN(=SB)が最初に行動 → Bob
+    await expect(page.getByText("Bobさん")).toBeVisible();
     await expect(page.getByText("あなたの番です")).toBeVisible();
   });
 
@@ -84,9 +84,9 @@ test.describe("ボタンプレイヤー選択（初回ハンド）", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // Bob → fold で即完了
-    await goThroughPlayerIntro(page, "Bob");
-    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+    // ヘッズアップ プリフロップ: Alice(BTN=SB) → fold で即完了
+    await goThroughPlayerIntro(page, "Alice");
+    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
     await chooseAction(page, "フォールド");
     await proceedFromTurnComplete(page);
 

--- a/e2e/play-card-dedup.spec.ts
+++ b/e2e/play-card-dedup.spec.ts
@@ -6,9 +6,9 @@ import { selectCard } from "./helpers/card-selector";
 test.describe("カード重複防止", () => {
   /**
    * 共通セットアップ:
-   * 2人プレイ → hand-start → BTN選択 → カードを配る → Bob(index 1)のplayer-intro → card-input
-   * Bob が ♠A, ♥K を選択して確定 → action(チェック) → turn-complete
-   * → Alice(index 0)のplayer-intro → card-input まで進める
+   * 2人プレイ → hand-start → BTN選択(Alice) → カードを配る → Alice(BTN=SB)のplayer-intro → card-input
+   * Alice が ♠A, ♥K を選択して確定 → action(チェック) → turn-complete
+   * → Bob(BB)のplayer-intro → card-input まで進める
    */
   async function setupToSecondPlayerCardInput(page: import("@playwright/test").Page) {
     const { session } = createTwoPlayerSession();
@@ -20,36 +20,36 @@ test.describe("カード重複防止", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // Bob の player-intro
-    await expect(page.getByText("Bobさん")).toBeVisible();
+    // Alice の player-intro (ヘッズアップ プリフロップ: BTN=SB が先)
+    await expect(page.getByText("Aliceさん")).toBeVisible();
     await page.getByRole("button", { name: "OK、準備できました" }).click();
 
-    // Bob の card-input: ♠A, ♥K を選択
-    await expect(page.getByText("Bobさんのカード")).toBeVisible();
+    // Alice の card-input: ♠A, ♥K を選択
+    await expect(page.getByText("Aliceさんのカード")).toBeVisible();
     await selectCard(page, "spade", "A");
     await selectCard(page, "heart", "K");
     await page.getByRole("button", { name: /カードを確定/ }).click();
 
-    // Bob の action-select: チェック
+    // Alice の action-select: チェック
     await expect(page.getByText("アクションを選択してください")).toBeVisible();
     await page.getByRole("button", { name: "チェック" }).click();
 
-    // turn-complete → Alice へ
+    // turn-complete → Bob へ
     await expect(page.getByText("記録完了！")).toBeVisible();
     await page.getByRole("button", { name: "次の人の準備ができました" }).click();
 
-    // Alice の player-intro
-    await expect(page.getByText("Aliceさん")).toBeVisible();
+    // Bob の player-intro
+    await expect(page.getByText("Bobさん")).toBeVisible();
     await page.getByRole("button", { name: "OK、準備できました" }).click();
 
-    // Alice の card-input フェーズ
-    await expect(page.getByText("Aliceさんのカード")).toBeVisible();
+    // Bob の card-input フェーズ
+    await expect(page.getByText("Bobさんのカード")).toBeVisible();
   }
 
   test("前のプレイヤーが使用したカードはタップしても選択されない", async ({ page }) => {
     await setupToSecondPlayerCardInput(page);
 
-    // Bob が使った ♠A をタップ → 選択されないことを検証
+    // Alice が使った ♠A をタップ → 選択されないことを検証
     await selectCard(page, "spade", "A");
 
     // まだ「1枚目を選択」の状態のまま = 選択されていない
@@ -59,7 +59,7 @@ test.describe("カード重複防止", () => {
   test("前のプレイヤーが使用したカード（2枚目）もタップしても選択されない", async ({ page }) => {
     await setupToSecondPlayerCardInput(page);
 
-    // Bob が使った ♥K をタップ → 選択されないことを検証
+    // Alice が使った ♥K をタップ → 選択されないことを検証
     await selectCard(page, "heart", "K");
 
     // まだ「1枚目を選択」の状態のまま

--- a/e2e/play-dealer-turn.spec.ts
+++ b/e2e/play-dealer-turn.spec.ts
@@ -10,8 +10,8 @@ import {
 } from "./helpers/play-flow";
 
 test.describe("dealer-turn フェーズ", () => {
-  // hand-start → Bob プリフロップ → Alice プリフロップ → dealer-turn (flop) まで進める
-  // Hand 1: BTN=Alice(index 0) → Bob(index 1)が先に行動
+  // hand-start → Alice プリフロップ → Bob プリフロップ → dealer-turn (flop) まで進める
+  // Hand 1: BTN=Alice(index 0) → ヘッズアップでは BTN(=SB) が先に行動
   async function setupToDealerTurn(page: import("@playwright/test").Page) {
     const { session } = createTwoPlayerSession();
     await setupApiMocks(page, session);
@@ -22,15 +22,15 @@ test.describe("dealer-turn フェーズ", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // Bob: intro → cards → action → turn-complete (BTNの次 = 最初に行動)
-    await goThroughPlayerIntro(page, "Bob");
-    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+    // Alice: intro → cards → action → turn-complete (ヘッズアップ プリフロップ: BTN=SB が先)
+    await goThroughPlayerIntro(page, "Alice");
+    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 
-    // Alice: intro → cards → action → turn-complete
-    await goThroughPlayerIntro(page, "Alice");
-    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
+    // Bob: intro → cards → action → turn-complete
+    await goThroughPlayerIntro(page, "Bob");
+    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 

--- a/e2e/play-full-game.spec.ts
+++ b/e2e/play-full-game.spec.ts
@@ -19,22 +19,22 @@ test.describe("統合テスト: 2人で1ハンド完走", () => {
     await page.goto(`/play/${session.id}`);
 
     // === hand-start ===
-    // Hand 1: BTN=Alice(index 0) → Bob(index 1)が先に行動
+    // Hand 1: BTN=Alice(index 0) → ヘッズアップでは BTN(=SB) が先に行動
     await expect(page.getByText("ゲーム開始")).toBeVisible();
     await page.getByRole("button", { name: "5回", exact: true }).click();
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
     // === プリフロップ ===
-    // Bob (BTNの次 = 最初に行動)
-    await goThroughPlayerIntro(page, "Bob");
-    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
+    // Alice (BTN=SB = 最初に行動)
+    await goThroughPlayerIntro(page, "Alice");
+    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 
-    // Alice
-    await goThroughPlayerIntro(page, "Alice");
-    await inputHoleCards(page, { suit: "spade", rank: "A" }, { suit: "heart", rank: "K" });
+    // Bob (BB)
+    await goThroughPlayerIntro(page, "Bob");
+    await inputHoleCards(page, { suit: "diamond", rank: "Q" }, { suit: "club", rank: "J" });
     await chooseAction(page, "チェック");
     await proceedFromTurnComplete(page);
 

--- a/e2e/play-hand-start.spec.ts
+++ b/e2e/play-hand-start.spec.ts
@@ -54,8 +54,8 @@ test.describe("hand-start フェーズ", () => {
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
 
-    // player-intro: BTN(Alice)の次のプレイヤー = Bob
-    await expect(page.getByText("Bobさん")).toBeVisible();
+    // ヘッズアップ プリフロップ: BTN(=SB)が最初に行動 → Alice
+    await expect(page.getByText("Aliceさん")).toBeVisible();
     await expect(page.getByText("あなたの番です")).toBeVisible();
     await expect(page.getByRole("button", { name: "OK、準備できました" })).toBeVisible();
   });

--- a/e2e/play-player-turn.spec.ts
+++ b/e2e/play-player-turn.spec.ts
@@ -5,7 +5,7 @@ import { selectCard } from "./helpers/card-selector";
 
 test.describe("プレイヤーターン", () => {
   // 各テスト共通: hand-start → "カードを配る" → player-intro まで進める
-  // Hand 1: BTN=Alice(index 0) → 最初に行動するのは Bob(index 1)
+  // Hand 1: BTN=Alice(index 0) → ヘッズアップ プリフロップは BTN(=SB) が最初に行動 → Alice
   async function setupToPlayerIntro(page: import("@playwright/test").Page) {
     const { session } = createTwoPlayerSession();
     await setupApiMocks(page, session);
@@ -13,13 +13,13 @@ test.describe("プレイヤーターン", () => {
     await expect(page.getByText("ゲーム開始")).toBeVisible();
     await page.getByText("1. Alice").click();
     await page.getByRole("button", { name: "カードを配る" }).click();
-    await expect(page.getByText("Bobさん")).toBeVisible();
+    await expect(page.getByText("Aliceさん")).toBeVisible();
   }
 
   test("player-intro: プライバシー画面の表示", async ({ page }) => {
     await setupToPlayerIntro(page);
 
-    await expect(page.getByText("Bobさん")).toBeVisible();
+    await expect(page.getByText("Aliceさん")).toBeVisible();
     await expect(page.getByText("あなたの番です")).toBeVisible();
     await expect(
       page.getByText("他の人に画面が見えないことを確認してから")
@@ -33,7 +33,7 @@ test.describe("プレイヤーターン", () => {
     await page.getByRole("button", { name: "OK、準備できました" }).click();
 
     // card-input フェーズ
-    await expect(page.getByText("Bobさんのカード")).toBeVisible();
+    await expect(page.getByText("Aliceさんのカード")).toBeVisible();
     await expect(page.getByText("配られたカードを選択してください")).toBeVisible();
 
     // カード2枚選択
@@ -99,7 +99,7 @@ test.describe("プレイヤーターン", () => {
     await page.getByRole("button", { name: "チェック" }).click();
 
     await expect(page.getByText("記録完了！")).toBeVisible();
-    await expect(page.getByText(/Alice/)).toBeVisible();
+    await expect(page.getByText(/Bob/)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "次の人の準備ができました" })
     ).toBeVisible();

--- a/src/app/play/[sessionId]/page.tsx
+++ b/src/app/play/[sessionId]/page.tsx
@@ -27,6 +27,7 @@ import {
   deriveFoldedPlayerIds,
   derivePlayersToAct,
   getFirstActivePlayerAfterButton,
+  getPreflopFirstActivePlayer,
   getStreetFromPhase,
 } from "@/lib/game-state";
 
@@ -306,7 +307,7 @@ export default function PlayPage() {
         .map((p, i) => ({ player: p, index: i }))
         .filter(({ player }) => player.isActive)
         .map(({ index }) => index);
-      const firstPlayerIndex = getFirstActivePlayerAfterButton(buttonIndex, activeIndices, players.length) ?? activeIndices[0] ?? 0;
+      const firstPlayerIndex = getPreflopFirstActivePlayer(buttonIndex, activeIndices, players.length) ?? activeIndices[0] ?? 0;
       const nextPhase: PersistedGamePhase = { step: "player-intro", playerIndex: firstPlayerIndex, street: "preflop" };
       const res = await fetch(`/api/sessions/${sessionId}/hands`, {
         method: "POST",

--- a/src/lib/game-state.ts
+++ b/src/lib/game-state.ts
@@ -116,6 +116,37 @@ export const getFirstActivePlayerAfterButton = (
   return null;
 };
 
+/**
+ * プリフロップで最初に行動するプレイヤーのインデックスを返す。
+ * - 3人以上: SB と BB をスキップした次のアクティブプレイヤー（UTG）
+ * - ヘッズアップ（2人）: BTN（=SB）が最初に行動
+ */
+export const getPreflopFirstActivePlayer = (
+  buttonIndex: number,
+  activePlayerIndices: readonly number[],
+  playerCount: number
+): number | null => {
+  const activeCount = activePlayerIndices.length;
+  if (activeCount === 0) return null;
+  if (activeCount === 1) return activePlayerIndices[0] ?? null;
+  if (activeCount === 2) {
+    return activePlayerIndices.includes(buttonIndex)
+      ? buttonIndex
+      : (activePlayerIndices[0] ?? null);
+  }
+
+  const activeSet = new Set(activePlayerIndices);
+  let activeFound = 0;
+  for (let offset = 1; offset <= playerCount * 2; offset++) {
+    const idx = (buttonIndex + offset) % playerCount;
+    if (activeSet.has(idx)) {
+      activeFound++;
+      if (activeFound === 3) return idx;
+    }
+  }
+  return null;
+};
+
 /** GamePhaseからストリートを抽出する */
 export const getStreetFromPhase = (
   phase: { readonly step: string; readonly street?: Street }

--- a/src/lib/game-state.ts
+++ b/src/lib/game-state.ts
@@ -137,7 +137,7 @@ export const getPreflopFirstActivePlayer = (
 
   const activeSet = new Set(activePlayerIndices);
   let activeFound = 0;
-  for (let offset = 1; offset <= playerCount * 2; offset++) {
+  for (let offset = 1; offset <= playerCount; offset++) {
     const idx = (buttonIndex + offset) % playerCount;
     if (activeSet.has(idx)) {
       activeFound++;


### PR DESCRIPTION
## Summary

issue #30 の対応。ボタン設定後のプリフロップで SB の位置から始まっていたのを、SB/BB をスキップした次のアクティブプレイヤー（UTG）から開始するよう修正。

- 3人以上: BTN+SB+BB の次のアクティブプレイヤー（UTG）から開始
- ヘッズアップ（2人）: BTN(=SB) が最初に行動する標準ルールに準拠
- ポストフロップは従来通り BTN の次（SB）から開始（変更なし）

## Changes

- `src/lib/game-state.ts` — `getPreflopFirstActivePlayer` を新規追加
- `src/app/play/[sessionId]/page.tsx` — `startHand` のプリフロップ開始位置決定に新ヘルパーを使用
- E2E テスト 7 ファイル — 新仕様に合わせて期待値を更新

closes #30

## Test plan

- [x] \`npm run build\` が成功する
- [x] 該当 E2E テスト（play-button-rotation, play-button-selection, play-hand-start, play-player-turn, play-card-dedup, play-dealer-turn, play-full-game）が全てパスする
- [ ] 手動確認: 6人プレイで BTN 設定後、UTG（BTN から3つ後）から行動開始することを確認
- [ ] 手動確認: 3人プレイで BTN 設定後、BTN 自身から行動開始することを確認
- [ ] 手動確認: 2人プレイ（ヘッズアップ）で BTN(=SB) から行動開始することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)