### PR TITLE
導入企業向けの診断サンプル10パターンと閲覧ページを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "typescript": "^5"
       }
     },
@@ -312,6 +313,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3844,6 +4287,48 @@
         "docs",
         "benchmarks"
       ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -8061,6 +8546,41 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "simulate": "tsx src/simulations/runner.ts",
+    "simulate:diagnose": "tsx --env-file=.env.local src/simulations/diagnose.ts",
     "test:e2e": "FIREBASE_PROJECT_ID=test FIREBASE_CLIENT_EMAIL=test@test.iam FIREBASE_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----' OPENAI_API_KEY=sk-test playwright test",
     "test:e2e:ui": "FIREBASE_PROJECT_ID=test FIREBASE_CLIENT_EMAIL=test@test.iam FIREBASE_PRIVATE_KEY='-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----' OPENAI_API_KEY=sk-test playwright test --ui"
   },
@@ -28,6 +30,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   }
 }

--- a/src/app/samples/[id]/page.tsx
+++ b/src/app/samples/[id]/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { formatDateTime } from "@/utils/format";
+import DiagnosisCard from "@/components/result/DiagnosisCard";
+import RadarChartDisplay from "@/components/result/RadarChartDisplay";
+import StatsSummary from "@/components/result/StatsSummary";
+import AdviceSection from "@/components/result/AdviceSection";
+import PlayerPlayReview from "@/components/result/PlayerPlayReview";
+import { SAMPLE_RESULTS, findSampleById } from "@/simulations/results";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export const dynamicParams = false;
+
+export const generateStaticParams = (): Array<{ id: string }> =>
+  SAMPLE_RESULTS.map((s) => ({ id: s.scenario.id }));
+
+export const generateMetadata = async ({ params }: RouteParams): Promise<Metadata> => {
+  const { id } = await params;
+  const sample = findSampleById(id);
+  if (!sample) return { title: "サンプルが見つかりません" };
+  return {
+    title: `${sample.scenario.persona} (${sample.scenario.playerName}) | 診断サンプル`,
+    description: sample.scenario.summary,
+  };
+};
+
+export default async function SampleDetailPage({ params }: RouteParams) {
+  const { id } = await params;
+  const sample = findSampleById(id);
+  if (!sample) notFound();
+
+  const { scenario, diagnosis, hands, players } = sample;
+
+  return (
+    <main className="min-h-screen bg-surface pb-16">
+      <header className="bg-poker-black px-4 py-8 text-center text-white print:bg-white print:text-foreground">
+        <Link
+          href="/samples"
+          className="mb-3 inline-block text-xs text-poker-gold/80 hover:text-poker-gold"
+        >
+          ← サンプル一覧へ戻る
+        </Link>
+        <p className="text-sm text-poker-gold">サンプル診断結果</p>
+        <h1 className="mt-2 text-3xl font-bold">{scenario.playerName} さんの診断結果</h1>
+        <p className="mt-2 text-sm text-white/80">{scenario.persona}</p>
+      </header>
+
+      <div className="mx-auto max-w-2xl space-y-8 px-4 pt-8">
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
+          <p className="font-semibold">このサンプルのプレイヤー像</p>
+          <p className="mt-2 leading-relaxed">{scenario.summary}</p>
+        </div>
+
+        <DiagnosisCard
+          pokerStyle={diagnosis.pokerStyle}
+          businessType={diagnosis.businessType}
+          businessTypeDescription={diagnosis.businessTypeDescription}
+          strengths={diagnosis.strengths}
+          growthPotentials={diagnosis.growthPotentials}
+        />
+
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-lg">
+          <RadarChartDisplay axes={diagnosis.axes} />
+        </div>
+
+        <StatsSummary stats={diagnosis.stats} />
+
+        <PlayerPlayReview
+          playerId={diagnosis.playerId}
+          hands={hands}
+          players={players}
+        />
+
+        <AdviceSection advice={diagnosis.advice} />
+
+        <div className="border-t border-gray-200 pt-6 text-center print:border-none">
+          <p className="text-xs text-muted">
+            診断生成日時: {formatDateTime(diagnosis.createdAt)}
+          </p>
+          <p className="mt-1 text-xs text-muted">
+            ※このページは導入企業向けの参考サンプルです。プレイ履歴は意図的に作成された架空データです。
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/samples/page.tsx
+++ b/src/app/samples/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import type { PokerStyle } from "@/types";
+import { SAMPLE_RESULTS } from "@/simulations/results";
+
+const STYLE_BADGE: Readonly<
+  Record<PokerStyle, { readonly label: string; readonly className: string }>
+> = {
+  "loose-aggressive": {
+    label: "LAG",
+    className: "bg-red-100 text-red-700 border-red-200",
+  },
+  "tight-aggressive": {
+    label: "TAG",
+    className: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  "loose-passive": {
+    label: "LP",
+    className: "bg-green-100 text-green-700 border-green-200",
+  },
+  "tight-passive": {
+    label: "TP",
+    className: "bg-amber-100 text-amber-800 border-amber-200",
+  },
+};
+
+export const metadata: Metadata = {
+  title: "診断サンプル | Company Poker Assessment",
+  description:
+    "10種類のプレイスタイルに対する診断サンプルを実データで確認できます。",
+};
+
+export default function SamplesIndexPage() {
+  if (SAMPLE_RESULTS.length === 0) {
+    return (
+      <main className="min-h-screen bg-surface px-4 py-12">
+        <div className="mx-auto max-w-2xl rounded-2xl border border-amber-200 bg-amber-50 p-8 text-center">
+          <h1 className="text-xl font-bold text-amber-900">サンプルが未生成です</h1>
+          <p className="mt-3 text-sm text-amber-800">
+            ターミナルで <code className="rounded bg-amber-100 px-2 py-0.5">npm run simulate:diagnose</code> を実行してサンプルデータを生成してください。
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-surface pb-16">
+      <header className="bg-poker-black px-4 py-10 text-center text-white">
+        <p className="text-sm text-poker-gold">Company Poker Assessment</p>
+        <h1 className="mt-2 text-3xl font-bold">診断サンプル集</h1>
+        <p className="mt-3 text-sm text-white/80">
+          実際のプレイデータと AI 診断結果の {SAMPLE_RESULTS.length} パターンを掲載しています
+        </p>
+      </header>
+
+      <section className="mx-auto mt-8 max-w-5xl px-4">
+        <p className="mb-6 text-sm text-foreground/70">
+          各カードをタップすると、プレイの軌跡・統計・AIによる6軸診断とアドバイスを確認できます。
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {SAMPLE_RESULTS.map((sample) => {
+            const badge = STYLE_BADGE[sample.diagnosis.pokerStyle];
+            return (
+              <Link
+                key={sample.scenario.id}
+                href={`/samples/${sample.scenario.id}`}
+                className="group rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-medium text-foreground/60">
+                      {sample.scenario.persona}
+                    </p>
+                    <h2 className="mt-1 text-lg font-bold text-foreground">
+                      {sample.scenario.playerName}
+                    </h2>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-bold ${badge.className}`}
+                  >
+                    {badge.label}
+                  </span>
+                </div>
+
+                <p className="mt-3 line-clamp-3 text-sm text-foreground/70">
+                  {sample.scenario.summary}
+                </p>
+
+                <div className="mt-4 rounded-lg bg-poker-black/5 px-3 py-2">
+                  <p className="text-xs text-foreground/60">診断タイプ</p>
+                  <p className="mt-0.5 text-sm font-bold text-poker-black">
+                    {sample.diagnosis.businessType}
+                  </p>
+                </div>
+
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center text-[11px] text-foreground/70">
+                  <div className="rounded bg-gray-50 px-1 py-1">
+                    <p className="text-foreground/50">VPIP</p>
+                    <p className="font-bold text-foreground">
+                      {sample.diagnosis.stats.vpip.toFixed(0)}%
+                    </p>
+                  </div>
+                  <div className="rounded bg-gray-50 px-1 py-1">
+                    <p className="text-foreground/50">PFR</p>
+                    <p className="font-bold text-foreground">
+                      {sample.diagnosis.stats.pfr.toFixed(0)}%
+                    </p>
+                  </div>
+                  <div className="rounded bg-gray-50 px-1 py-1">
+                    <p className="text-foreground/50">AF</p>
+                    <p className="font-bold text-foreground">
+                      {sample.diagnosis.stats.aggressionFactor.toFixed(2)}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-right text-xs font-medium text-poker-gold group-hover:underline">
+                  詳細を見る →
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/simulations/diagnose.ts
+++ b/src/simulations/diagnose.ts
@@ -1,0 +1,94 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { calculatePokerStats } from "@/lib/poker-stats";
+import { determinePokerStyle, getBusinessType } from "@/lib/diagnosis-mapper";
+import { DIAGNOSIS_SYSTEM_PROMPT, buildDiagnosisUserPrompt } from "@/lib/prompt";
+import { generateDiagnosis } from "@/lib/openai";
+import type { DiagnosisResult, Player } from "@/types";
+import { HERO_ID, SCENARIOS, VILLAIN_ID } from "./scenarios";
+import type { SampleResult } from "./types";
+
+const OUTPUT_PATH = resolve("src/simulations/results/data.json");
+
+const buildPlayers = (heroName: string, createdAt: string): readonly Player[] => [
+  {
+    id: HERO_ID,
+    name: heroName,
+    seatNumber: 1,
+    joinedAt: createdAt,
+    isActive: true,
+  },
+  {
+    id: VILLAIN_ID,
+    name: "対戦相手",
+    seatNumber: 2,
+    joinedAt: createdAt,
+    isActive: true,
+  },
+];
+
+const main = async (): Promise<void> => {
+  if (!process.env["OPENAI_API_KEY"]) {
+    throw new Error("OPENAI_API_KEY が未設定です。.env.local を確認してください。");
+  }
+
+  const samples: SampleResult[] = [];
+
+  for (const scenario of SCENARIOS) {
+    const stats = calculatePokerStats(HERO_ID, scenario.hands);
+    const pokerStyle = determinePokerStyle(stats);
+    const businessType = getBusinessType(pokerStyle);
+
+    console.log(
+      `[${scenario.id}] ${scenario.playerName} (${pokerStyle}) — calling OpenAI...`
+    );
+
+    const userPrompt = buildDiagnosisUserPrompt(
+      scenario.playerName,
+      stats,
+      pokerStyle,
+      businessType.name
+    );
+
+    const ai = await generateDiagnosis(DIAGNOSIS_SYSTEM_PROMPT, userPrompt);
+
+    const createdAt = new Date().toISOString();
+
+    const diagnosis: DiagnosisResult = {
+      playerId: HERO_ID,
+      playerName: scenario.playerName,
+      pokerStyle,
+      businessType: businessType.name,
+      businessTypeDescription: businessType.description,
+      axes: ai.axes,
+      stats,
+      advice: ai.advice,
+      strengths: ai.strengths,
+      growthPotentials: ai.growthPotentials,
+      createdAt,
+    };
+
+    samples.push({
+      scenario: {
+        id: scenario.id,
+        playerName: scenario.playerName,
+        persona: scenario.persona,
+        summary: scenario.summary,
+        expectedStyle: scenario.expectedStyle,
+      },
+      diagnosis,
+      hands: scenario.hands,
+      players: buildPlayers(scenario.playerName, createdAt),
+    });
+
+    console.log(`  → ${businessType.name} / advice ${ai.advice.length} 文字`);
+  }
+
+  writeFileSync(OUTPUT_PATH, JSON.stringify(samples, null, 2) + "\n", "utf8");
+  console.log(`\n✓ Wrote ${samples.length} sample results to ${OUTPUT_PATH}`);
+};
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/simulations/results/data.json
+++ b/src/simulations/results/data.json
@@ -1,0 +1,9108 @@
+[
+  {
+    "scenario": {
+      "id": "lag-1",
+      "playerName": "鈴木 大輔",
+      "persona": "攻めの新規事業リーダー",
+      "summary": "ほぼ全てのハンドに参戦し、強気にレイズで主導権を握り続ける。撤退判断も速く、不利と見るや躊躇なく次へ向かう。",
+      "expectedStyle": "loose-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "鈴木 大輔",
+      "pokerStyle": "loose-aggressive",
+      "businessType": "革新的開拓者タイプ",
+      "businessTypeDescription": "大胆な意思決定と高い行動力で新しい市場やプロジェクトを切り拓く。リスクを恐れず挑戦し、チームに勢いをもたらす存在。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 92,
+          "description": "大胆さと勝負勘で機会を掴む推進力"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 90,
+          "description": "迷いなく前に出る決断力で展開が速い"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 82,
+          "description": "状況の要点を素早く捉え最適化できる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 88,
+          "description": "相手に合わせて戦略を切り替える柔軟さ"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 86,
+          "description": "高い勝負所でも堂々と攻め切る強さ"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 80,
+          "description": "攻めの投資配分が巧みで成果に直結する"
+        }
+      ],
+      "stats": {
+        "vpip": 75,
+        "pfr": 66.66666666666666,
+        "aggressionFactor": 2.111111111111111,
+        "foldPercentage": 10.81081081081081,
+        "cbetPercentage": 62.5,
+        "showdownPercentage": 58.333333333333336,
+        "totalHands": 12
+      },
+      "advice": "鈴木 大輔さんは、攻めの一手で市場を切り拓く革新的開拓者。高い参加率とレイズ率は、商機を見つけた瞬間に動ける証です。次は「勝ち筋の再現性」を言語化し、意思決定の型として共有すると、組織を巻き込む推進力がさらに加速します。",
+      "strengths": [
+        "機会を逃さず主導権を握る攻めの推進力",
+        "高圧下でもブレない大胆な意思決定",
+        "相手や局面に応じた柔軟な戦略転換"
+      ],
+      "growthPotentials": [
+        "勝ちパターンをフレーム化してチームに展開",
+        "攻めの投資判断を指標化し再現性を強化",
+        "データ検証のサイクルで革新速度を最大化"
+      ],
+      "createdAt": "2026-05-06T05:04:48.781Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": false
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "鈴木 大輔",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:04:48.781Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:04:48.781Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "lag-2",
+      "playerName": "高橋 美咲",
+      "persona": "直感型スタートアップ創業者",
+      "summary": "勘とスピード重視で参加判断を下し、ベットで相手にプレッシャーをかけ続ける。完璧な情報を待たず、自ら状況を作り出す。",
+      "expectedStyle": "loose-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "高橋 美咲",
+      "pokerStyle": "loose-aggressive",
+      "businessType": "革新的開拓者タイプ",
+      "businessTypeDescription": "大胆な意思決定と高い行動力で新しい市場やプロジェクトを切り拓く。リスクを恐れず挑戦し、チームに勢いをもたらす存在。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 92,
+          "description": "大胆さと勝負勘で機会を掴む推進力が抜群"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 90,
+          "description": "迷いなく打ち手を選び、展開を自ら動かせる"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 84,
+          "description": "状況を読み切り、最適な圧力配分ができる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 88,
+          "description": "相手に合わせて攻め筋を変える柔軟さが光る"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 86,
+          "description": "高頻度の勝負所でも平常心で主導権を握れる"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 80,
+          "description": "アクション量を武器に投資対効果を作り出せる"
+        }
+      ],
+      "stats": {
+        "vpip": 66.66666666666666,
+        "pfr": 50,
+        "aggressionFactor": 3.4,
+        "foldPercentage": 17.647058823529413,
+        "cbetPercentage": 83.33333333333334,
+        "showdownPercentage": 41.66666666666667,
+        "totalHands": 12
+      },
+      "advice": "革新的開拓者タイプらしく、攻めの姿勢で市場を切り拓く力が際立っています。高い仕掛け頻度と継続的な主導権で、周囲を巻き込みながら成果を最短距離で取りにいける人材です。勝ち筋の再現性を言語化すると、さらに影響力が加速します。",
+      "strengths": [
+        "機会を逃さない大胆なチャレンジ力",
+        "主導権を握り続ける推進力と交渉力",
+        "相手の反応を見て戦略を切り替える柔軟性"
+      ],
+      "growthPotentials": [
+        "攻めの判断基準を型化し、チームに展開できる可能性",
+        "データの蓄積で意思決定の精度と再現性がさらに高まる可能性",
+        "勝負所のストーリー設計で周囲の巻き込み力が一段と伸びる可能性"
+      ],
+      "createdAt": "2026-05-06T05:04:57.601Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": false
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "高橋 美咲",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:04:57.601Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:04:57.601Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "lag-3",
+      "playerName": "佐々木 健",
+      "persona": "強気のセールス・ハンター",
+      "summary": "圧倒的な行動量で全ての商談に首を突っ込み、押しの一手で契約を取りに行く。負けが見えたハンドの撤退も鮮やかでロスを最小化。",
+      "expectedStyle": "loose-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "佐々木 健",
+      "pokerStyle": "loose-aggressive",
+      "businessType": "革新的開拓者タイプ",
+      "businessTypeDescription": "大胆な意思決定と高い行動力で新しい市場やプロジェクトを切り拓く。リスクを恐れず挑戦し、チームに勢いをもたらす存在。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 92,
+          "description": "大胆さと勝負勘で機会を掴む挑戦者"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 90,
+          "description": "迷いなく即断し、主導権を握る推進力"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 84,
+          "description": "状況を読み切り最適手を組み立てる知性派"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 88,
+          "description": "相手に合わせて戦略を変える柔軟な強さ"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 86,
+          "description": "高い勝負所でも攻め切れる胆力が光る"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 80,
+          "description": "攻めの配分が上手く、資源を成果に変える"
+        }
+      ],
+      "stats": {
+        "vpip": 83.33333333333334,
+        "pfr": 75,
+        "aggressionFactor": 4.166666666666667,
+        "foldPercentage": 10,
+        "cbetPercentage": 77.77777777777779,
+        "showdownPercentage": 58.333333333333336,
+        "totalHands": 12
+      },
+      "advice": "佐々木 健さんはloose-aggressiveらしい圧倒的な行動量と主導権で、未開拓の市場を切り拓く革新的開拓者。強気の一手を積み重ねて流れを作れるので、仮説→実行→検証の回転をさらに速めるほど、周囲を巻き込み大きな成果へ一直線です。",
+      "strengths": [
+        "機会を逃さず踏み込む高い挑戦力",
+        "主導権を握り続ける実行力と推進力",
+        "相手の反応を見て戦略を切り替える柔軟性"
+      ],
+      "growthPotentials": [
+        "得意の攻めを再現可能な型にして組織展開する力",
+        "データと直感を統合し、意思決定精度をさらに高める可能性",
+        "勝ち筋の発見をプロダクト/事業戦略に落とし込む伸びしろ"
+      ],
+      "createdAt": "2026-05-06T05:05:10.137Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": false
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "佐々木 健",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:10.137Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:10.137Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "tag-1",
+      "playerName": "中村 俊介",
+      "persona": "切れ味鋭い戦略コンサルタント",
+      "summary": "参加するハンドを厳選し、勝てる場面でだけ強くベットを打ち抜く。アクション時はほぼ常にレイズで、選択と集中を体現するスタイル。",
+      "expectedStyle": "tight-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "中村 俊介",
+      "pokerStyle": "tight-aggressive",
+      "businessType": "戦略的リーダータイプ",
+      "businessTypeDescription": "慎重な分析に基づいて的確な判断を下し、ここぞという場面で力強くリードする。効率的な資源配分と明確なビジョンでチームを導く。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 78,
+          "description": "勝ち筋を見極めて大胆に踏み込める"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 90,
+          "description": "迷いなく最適解を選び切る決断力が光る"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 86,
+          "description": "情報を絞り込み精度高く判断できる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 80,
+          "description": "状況に合わせて攻守を切り替えるのが巧み"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 84,
+          "description": "高圧でも攻めの姿勢を保てる強さがある"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 82,
+          "description": "参加局面を厳選し効率よく成果を出せる"
+        }
+      ],
+      "stats": {
+        "vpip": 25,
+        "pfr": 25,
+        "aggressionFactor": 11,
+        "foldPercentage": 42.857142857142854,
+        "cbetPercentage": 100,
+        "showdownPercentage": 25,
+        "totalHands": 12
+      },
+      "advice": "タイトアグレッシブな精密さと高い攻撃性で、戦略を実行に落とし込む推進力が抜群です。強い局面で一気に主導権を握れるので、重要案件の意思決定者として大活躍。勝ちパターンの再現性を仕組み化すると、さらに飛躍できます。",
+      "strengths": [
+        "選択と集中で勝ち筋を最大化する戦略眼",
+        "主導権を握り切る強い実行力と推進力",
+        "高圧下でもブレない判断の安定感"
+      ],
+      "growthPotentials": [
+        "勝ちパターンの型化によるチーム展開力",
+        "局面別の打ち分けで影響力をさらに拡大",
+        "データ蓄積で意思決定の再現性を一段強化"
+      ],
+      "createdAt": "2026-05-06T05:05:20.336Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "中村 俊介",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:20.336Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:20.336Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "tag-2",
+      "playerName": "渡辺 真理子",
+      "persona": "投資判断のプロジェクト責任者",
+      "summary": "見送りの決断ができる慎重さと、ここぞという場面で大胆に資源を投下する判断力を併せ持つ。レンジは狭いが各ハンドへのコミットは深い。",
+      "expectedStyle": "tight-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "渡辺 真理子",
+      "pokerStyle": "tight-aggressive",
+      "businessType": "戦略的リーダータイプ",
+      "businessTypeDescription": "慎重な分析に基づいて的確な判断を下し、ここぞという場面で力強くリードする。効率的な資源配分と明確なビジョンでチームを導く。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 78,
+          "description": "勝ち筋のある挑戦に大胆に踏み込める"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 84,
+          "description": "好機を逃さず素早く主導権を握れる"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 82,
+          "description": "状況を整理し最適解へ一直線に導ける"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 76,
+          "description": "相手に合わせて戦術を洗練させられる"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 80,
+          "description": "強い局面でも迷いなく攻め切れる"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 79,
+          "description": "参加と撤退の切替が巧みで効率的"
+        }
+      ],
+      "stats": {
+        "vpip": 33.33333333333333,
+        "pfr": 25,
+        "aggressionFactor": 2.25,
+        "foldPercentage": 40.909090909090914,
+        "cbetPercentage": 100,
+        "showdownPercentage": 16.666666666666664,
+        "totalHands": 12
+      },
+      "advice": "tight-aggressiveらしく、厳選した機会に強く踏み込む戦略性が際立ちます。CBet率100%の主導権設計は、ビジネスでも交渉・推進力として大きな武器。データと現場感を掛け合わせ、再現性ある勝ち筋をさらに増やせます。",
+      "strengths": [
+        "勝ち筋を見極めて主導権を握る推進力",
+        "厳選した機会に集中投下できる戦略性",
+        "一貫したアグレッションで成果を取り切る力"
+      ],
+      "growthPotentials": [
+        "相手別の打ち手を増やし影響力を拡張",
+        "意思決定の型化でチームの再現性を強化",
+        "局面ごとのリスク配分を最適化し飛躍"
+      ],
+      "createdAt": "2026-05-06T05:05:29.103Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": false
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "渡辺 真理子",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:29.103Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:29.103Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "tag-3",
+      "playerName": "山田 哲也",
+      "persona": "厳選・集中型の財務責任者（CFO）",
+      "summary": "勝率の高いハンドだけに資本を投下し、参戦したら一気にレイズで攻める。極度に絞ったレンジで質の高いリターンを狙う典型的TAG。",
+      "expectedStyle": "tight-aggressive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "山田 哲也",
+      "pokerStyle": "tight-aggressive",
+      "businessType": "戦略的リーダータイプ",
+      "businessTypeDescription": "慎重な分析に基づいて的確な判断を下し、ここぞという場面で力強くリードする。効率的な資源配分と明確なビジョンでチームを導く。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 78,
+          "description": "勝ち筋を見極めて大胆に踏み込める"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 86,
+          "description": "迷いなく要所で即断できる実行力が光る"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 84,
+          "description": "状況を精密に読み、最適解へ導ける"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 80,
+          "description": "相手に合わせて戦略を自在に調整できる"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 82,
+          "description": "高圧でも攻めの姿勢を保てる安定感がある"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 88,
+          "description": "参加と撤退の配分が巧みで効率的に戦える"
+        }
+      ],
+      "stats": {
+        "vpip": 25,
+        "pfr": 16.666666666666664,
+        "aggressionFactor": 10,
+        "foldPercentage": 45,
+        "cbetPercentage": 100,
+        "showdownPercentage": 16.666666666666664,
+        "totalHands": 12
+      },
+      "advice": "タイトに選別しつつ、勝ち所では強く押し切る戦略眼が抜群です。CBetの一貫性は周囲を動かす推進力そのもの。強みの再現性を武器に、重要局面での意思決定をさらに型化すると、リーダーとしての影響力が一段と広がります。",
+      "strengths": [
+        "勝ち筋を見抜く戦略設計力",
+        "即断即決で局面を前に進める推進力",
+        "リソース配分の巧さによる高い効率性"
+      ],
+      "growthPotentials": [
+        "意思決定プロセスのテンプレ化で組織展開力が加速",
+        "強いアグレッションを活かした交渉・提案の突破力が拡張",
+        "データ蓄積により戦略の精度と再現性がさらに向上"
+      ],
+      "createdAt": "2026-05-06T05:05:37.177Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": false
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 12,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 12,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 25,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 25,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 50,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 50,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "山田 哲也",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:37.177Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:37.177Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "lp-1",
+      "playerName": "小林 由紀子",
+      "persona": "場を盛り上げるチームサポーター",
+      "summary": "ほとんどのハンドに付き合い、相手のベットには気持ちよくコールで応じる。場を壊さない柔らかい振る舞いで参加メンバーを和ませる。",
+      "expectedStyle": "loose-passive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "小林 由紀子",
+      "pokerStyle": "loose-passive",
+      "businessType": "協調的サポータータイプ",
+      "businessTypeDescription": "柔軟な姿勢で多くの場面に関わり、チームの調和を保つ。周囲の意見を尊重し、コミュニケーションを通じて組織を支える縁の下の力持ち。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 86,
+          "description": "挑戦機会を逃さず前向きに踏み出せる"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 74,
+          "description": "迷いを最小化し素早く次手を選べる"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 71,
+          "description": "状況を丁寧に見極め最適解を探れる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 92,
+          "description": "相手や場に合わせて自然に調整できる"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 88,
+          "description": "土壇場でも落ち着き粘り強く対応できる"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 77,
+          "description": "無理なく継続できる配分で成果を積める"
+        }
+      ],
+      "stats": {
+        "vpip": 66.66666666666666,
+        "pfr": 8.333333333333332,
+        "aggressionFactor": 0.05,
+        "foldPercentage": 14.285714285714285,
+        "cbetPercentage": 0,
+        "showdownPercentage": 58.333333333333336,
+        "totalHands": 12
+      },
+      "advice": "協調性と柔軟性が抜群で、周囲の力を引き出しながら前進できる稀有な存在です。参加率の高さは機会創出力の証。要所で「ここは主導権を取る」と決めた一手を増やすほど、影響力がさらに伸びます。",
+      "strengths": [
+        "周囲と調和しながら機会を広げる推進力",
+        "相手や状況に合わせて最適化できる柔軟性",
+        "プレッシャー下でも粘り強く成果へつなぐ力"
+      ],
+      "growthPotentials": [
+        "重要局面での主導権発揮により影響力が拡大",
+        "データ整理と振り返りで意思決定精度が向上",
+        "勝ち筋の場面での提案・発信がさらに輝く"
+      ],
+      "createdAt": "2026-05-06T05:05:46.360Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "小林 由紀子",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:46.360Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:46.360Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "lp-2",
+      "playerName": "森田 健介",
+      "persona": "共感型のチームリーダー",
+      "summary": "幅広い案件に関与しつつ、強引な主張は避けて相手のペースに合わせる。たまに自分から動くこともあるが、基本は調整役に徹する。",
+      "expectedStyle": "loose-passive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "森田 健介",
+      "pokerStyle": "loose-passive",
+      "businessType": "協調的サポータータイプ",
+      "businessTypeDescription": "柔軟な姿勢で多くの場面に関わり、チームの調和を保つ。周囲の意見を尊重し、コミュニケーションを通じて組織を支える縁の下の力持ち。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 82,
+          "description": "機会に臆せず踏み出す挑戦心が光る"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 74,
+          "description": "状況を見て素早く参加判断できる実行力"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 68,
+          "description": "相手の動きを丁寧に読み、精度を高められる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 86,
+          "description": "幅広い局面に自然体で合わせられる柔軟さ"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 80,
+          "description": "最後まで向き合い切る粘り強さが頼もしい"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 72,
+          "description": "無理に押さず調整し、安定運用へ繋げられる"
+        }
+      ],
+      "stats": {
+        "vpip": 58.333333333333336,
+        "pfr": 16.666666666666664,
+        "aggressionFactor": 0.13333333333333333,
+        "foldPercentage": 18.75,
+        "cbetPercentage": 0,
+        "showdownPercentage": 50,
+        "totalHands": 12
+      },
+      "advice": "協調的サポーターとして、場に参加して情報と関係性を育てる力が際立っています。さらに、要所で「小さな主導権」を取る一手（提案・確認・次アクションの提示）を増やすほど、周囲の安心感と成果の再現性が一段と高まります。",
+      "strengths": [
+        "関係構築を加速させる参加姿勢",
+        "相手に合わせて進める高い協調性",
+        "粘り強く最後までやり切る継続力"
+      ],
+      "growthPotentials": [
+        "重要局面での提案・意思表示を増やし影響力拡大",
+        "判断基準を言語化してチームの意思決定を高速化",
+        "小さな実験を回して成果パターンを再現可能にする"
+      ],
+      "createdAt": "2026-05-06T05:05:54.487Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "turn",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "森田 健介",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:05:54.487Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:05:54.487Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "tp-1",
+      "playerName": "伊藤 義隆",
+      "persona": "リスク回避型の財務管理者",
+      "summary": "参加ハンドを極限まで絞り、入った場合もコールやチェックで様子を見ながら堅実に運ぶ。一貫した規律で大きな損失を出さない。",
+      "expectedStyle": "tight-passive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "伊藤 義隆",
+      "pokerStyle": "tight-passive",
+      "businessType": "堅実な管理者タイプ",
+      "businessTypeDescription": "リスクを最小限に抑え、安定した運営を実現する。データと実績に基づいた堅実な判断で、組織の土台を守り維持する。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 42,
+          "description": "勝てる場面を厳選する堅実さが光ります"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 70,
+          "description": "迷いを減らし最適解へ素早く収束できます"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 78,
+          "description": "情報を精査し期待値の高い選択が得意です"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 66,
+          "description": "状況に合わせて守りと攻めを調整できます"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 74,
+          "description": "冷静さを保ち安定した判断を継続できます"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 88,
+          "description": "資源を守り増やす運用設計が非常に上手です"
+        }
+      ],
+      "stats": {
+        "vpip": 16.666666666666664,
+        "pfr": 8.333333333333332,
+        "aggressionFactor": 0.25,
+        "foldPercentage": 55.55555555555556,
+        "cbetPercentage": 0,
+        "showdownPercentage": 16.666666666666664,
+        "totalHands": 12
+      },
+      "advice": "伊藤さんは参加局面を厳選し、資源を守りながら確度の高い局面で成果を積み上げる名手です。意思決定の基準が明確なので、重要局面では「勝ち筋が見えたら一段踏み込む」運用を加えると、堅実さを保ったまま成果の伸びしろがさらに広がります。",
+      "strengths": [
+        "堅実なリスクコントロール",
+        "資源を守り抜く運用力",
+        "精度の高い状況判断"
+      ],
+      "growthPotentials": [
+        "勝ち筋が濃い局面での一歩踏み込む推進力",
+        "主導権を取る場面の設計（先手の打ち方）",
+        "小さく試して学ぶ改善サイクルの高速化"
+      ],
+      "createdAt": "2026-05-06T05:06:03.251Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "伊藤 義隆",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:06:03.251Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:06:03.251Z",
+        "isActive": true
+      }
+    ]
+  },
+  {
+    "scenario": {
+      "id": "tp-2",
+      "playerName": "藤田 由美",
+      "persona": "慎重派のオペレーション・マネージャー",
+      "summary": "参加判断は厳しめで、リスクの高いハンドは即撤退。入ったハンドでも控えめに動き、確実な状況以外で大きく賭けない安定志向。",
+      "expectedStyle": "tight-passive"
+    },
+    "diagnosis": {
+      "playerId": "hero",
+      "playerName": "藤田 由美",
+      "pokerStyle": "tight-passive",
+      "businessType": "堅実な管理者タイプ",
+      "businessTypeDescription": "リスクを最小限に抑え、安定した運営を実現する。データと実績に基づいた堅実な判断で、組織の土台を守り維持する。",
+      "axes": [
+        {
+          "key": "riskTolerance",
+          "label": "リスク許容度",
+          "score": 62,
+          "description": "堅実さを軸に、勝てる場面で踏み込める"
+        },
+        {
+          "key": "decisionSpeed",
+          "label": "意思決定スピード",
+          "score": 70,
+          "description": "参加基準が明確で、迷いの少ない判断が光る"
+        },
+        {
+          "key": "analyticalThinking",
+          "label": "分析的思考力",
+          "score": 78,
+          "description": "状況を見極め、期待値の高い選択を積み重ねる"
+        },
+        {
+          "key": "adaptability",
+          "label": "適応力・柔軟性",
+          "score": 68,
+          "description": "相手の動きに合わせ、無理なく最適解へ寄せる"
+        },
+        {
+          "key": "stressManagement",
+          "label": "プレッシャー耐性",
+          "score": 74,
+          "description": "冷静さを保ち、波に飲まれない安定感がある"
+        },
+        {
+          "key": "resourceManagement",
+          "label": "リソース管理力",
+          "score": 82,
+          "description": "手堅い資源配分で、損失を抑え成果を伸ばせる"
+        }
+      ],
+      "stats": {
+        "vpip": 25,
+        "pfr": 16.666666666666664,
+        "aggressionFactor": 0.5,
+        "foldPercentage": 42.857142857142854,
+        "cbetPercentage": 0,
+        "showdownPercentage": 25,
+        "totalHands": 12
+      },
+      "advice": "藤田 由美さんは、参加基準の明確さと堅実な資源配分で成果を積み上げる名手です。勝ち筋が見える局面での一歩が特に強みなので、その「確度の高い攻め」を再現可能な型として共有すると、チーム全体の生産性も一段と高まります。",
+      "strengths": [
+        "堅実な判断基準でブレない実行力",
+        "期待値重視の冷静な意思決定",
+        "資源配分とリスク管理の上手さ"
+      ],
+      "growthPotentials": [
+        "優位局面での主導権を取る打ち手の幅",
+        "成功パターンの言語化による組織展開力",
+        "少数データでも学びを最速で反映する改善力"
+      ],
+      "createdAt": "2026-05-06T05:06:12.217Z"
+    },
+    "hands": [
+      {
+        "id": "hand-1",
+        "handNumber": 1,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-2",
+        "handNumber": 2,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-3",
+        "handNumber": 3,
+        "buttonPlayerId": "villain",
+        "communityCards": [
+          {
+            "suit": "diamond",
+            "rank": "Q"
+          },
+          {
+            "suit": "club",
+            "rank": "J"
+          },
+          {
+            "suit": "heart",
+            "rank": "10"
+          },
+          {
+            "suit": "spade",
+            "rank": "9"
+          },
+          {
+            "suit": "diamond",
+            "rank": "8"
+          }
+        ],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "raise",
+            "amount": 6,
+            "street": "preflop",
+            "order": 0
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": 6,
+            "street": "preflop",
+            "order": 1
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "flop",
+            "order": 2
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "flop",
+            "order": 3
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "turn",
+            "order": 4
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "turn",
+            "order": 5
+          },
+          {
+            "playerId": "hero",
+            "type": "check",
+            "amount": null,
+            "street": "river",
+            "order": 6
+          },
+          {
+            "playerId": "villain",
+            "type": "call",
+            "amount": null,
+            "street": "river",
+            "order": 7
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "river",
+        "isComplete": true
+      },
+      {
+        "id": "hand-4",
+        "handNumber": 4,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-5",
+        "handNumber": 5,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-6",
+        "handNumber": 6,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-7",
+        "handNumber": 7,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-8",
+        "handNumber": 8,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-9",
+        "handNumber": 9,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-10",
+        "handNumber": 10,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-11",
+        "handNumber": 11,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      },
+      {
+        "id": "hand-12",
+        "handNumber": 12,
+        "buttonPlayerId": "villain",
+        "communityCards": [],
+        "playerHands": [
+          {
+            "playerId": "hero",
+            "holeCards": [
+              {
+                "suit": "spade",
+                "rank": "A"
+              },
+              {
+                "suit": "heart",
+                "rank": "K"
+              }
+            ]
+          },
+          {
+            "playerId": "villain",
+            "holeCards": null
+          }
+        ],
+        "actions": [
+          {
+            "playerId": "hero",
+            "type": "fold",
+            "amount": null,
+            "street": "preflop",
+            "order": 0
+          }
+        ],
+        "pot": 0,
+        "currentStreet": "preflop",
+        "isComplete": true
+      }
+    ],
+    "players": [
+      {
+        "id": "hero",
+        "name": "藤田 由美",
+        "seatNumber": 1,
+        "joinedAt": "2026-05-06T05:06:12.217Z",
+        "isActive": true
+      },
+      {
+        "id": "villain",
+        "name": "対戦相手",
+        "seatNumber": 2,
+        "joinedAt": "2026-05-06T05:06:12.217Z",
+        "isActive": true
+      }
+    ]
+  }
+]

--- a/src/simulations/results/index.ts
+++ b/src/simulations/results/index.ts
@@ -1,0 +1,7 @@
+import raw from "./data.json";
+import type { SampleResult } from "../types";
+
+export const SAMPLE_RESULTS: readonly SampleResult[] = raw as readonly SampleResult[];
+
+export const findSampleById = (id: string): SampleResult | undefined =>
+  SAMPLE_RESULTS.find((s) => s.scenario.id === id);

--- a/src/simulations/runner.ts
+++ b/src/simulations/runner.ts
@@ -1,0 +1,123 @@
+import { calculatePokerStats } from "@/lib/poker-stats";
+import { determinePokerStyle, getBusinessType } from "@/lib/diagnosis-mapper";
+import { VPIP_THRESHOLD, AF_THRESHOLD } from "@/constants/diagnosis";
+import type { Action, Hand, PokerStats, PokerStyle } from "@/types";
+import { HERO_ID, SCENARIOS, type Scenario } from "./scenarios";
+
+const STYLE_LABEL: Readonly<Record<PokerStyle, string>> = {
+  "loose-aggressive": "Loose-Aggressive (LAG)",
+  "tight-aggressive": "Tight-Aggressive (TAG)",
+  "loose-passive": "Loose-Passive (LP)",
+  "tight-passive": "Tight-Passive (TP)",
+};
+
+const ACTION_GLYPH: Readonly<Record<string, string>> = {
+  fold: "F",
+  check: "X",
+  call: "C",
+  raise: "R",
+};
+
+const formatStreets = (hand: Hand): string => {
+  const heroActions = hand.actions.filter((a) => a.playerId === HERO_ID);
+  const byStreet: Record<string, Action[]> = {
+    preflop: [],
+    flop: [],
+    turn: [],
+    river: [],
+  };
+  for (const a of heroActions) {
+    byStreet[a.street]?.push(a);
+  }
+  const segments: string[] = [];
+  for (const street of ["preflop", "flop", "turn", "river"] as const) {
+    const acts = byStreet[street] ?? [];
+    if (acts.length === 0) continue;
+    const tokens = acts.map((a) => {
+      const glyph = ACTION_GLYPH[a.type] ?? "?";
+      return a.amount !== null ? `${glyph}${a.amount}` : glyph;
+    });
+    segments.push(`${street.toUpperCase().slice(0, 2)}:${tokens.join(",")}`);
+  }
+  return segments.join(" → ");
+};
+
+const formatStats = (stats: PokerStats): string =>
+  [
+    `VPIP=${stats.vpip.toFixed(1)}%`,
+    `PFR=${stats.pfr.toFixed(1)}%`,
+    `AF=${stats.aggressionFactor.toFixed(2)}`,
+    `Fold=${stats.foldPercentage.toFixed(1)}%`,
+    `CBet=${stats.cbetPercentage.toFixed(1)}%`,
+    `SD=${stats.showdownPercentage.toFixed(1)}%`,
+    `Hands=${stats.totalHands}`,
+  ].join("  ");
+
+const renderScenario = (scenario: Scenario, index: number): string => {
+  const stats = calculatePokerStats(HERO_ID, scenario.hands);
+  const style = determinePokerStyle(stats);
+  const businessType = getBusinessType(style);
+  const matched = style === scenario.expectedStyle ? "OK" : "MISMATCH";
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("=".repeat(78));
+  lines.push(`シナリオ ${index + 1}/${SCENARIOS.length}: ${scenario.persona}`);
+  lines.push("=".repeat(78));
+  lines.push(`プレイヤー名     : ${scenario.playerName}`);
+  lines.push(`プロフィール    : ${scenario.summary}`);
+  lines.push("");
+  lines.push("【プレイ履歴 (12ハンド) — R=Raise / C=Call / X=Check / F=Fold】");
+  for (const hand of scenario.hands) {
+    lines.push(`  Hand ${String(hand.handNumber).padStart(2, " ")}: ${formatStreets(hand)}`);
+  }
+  lines.push("");
+  lines.push("【統計】");
+  lines.push(`  ${formatStats(stats)}`);
+  lines.push(
+    `  判定基準: VPIP閾値=${VPIP_THRESHOLD}% / AF閾値=${AF_THRESHOLD.toFixed(1)}`
+  );
+  lines.push("");
+  lines.push("【診断結果】");
+  lines.push(`  ポーカースタイル : ${STYLE_LABEL[style]}`);
+  lines.push(`  ビジネスタイプ   : ${businessType.name}`);
+  lines.push(`  説明             : ${businessType.description}`);
+  lines.push(
+    `  期待スタイル一致 : ${matched} (期待=${STYLE_LABEL[scenario.expectedStyle]})`
+  );
+  return lines.join("\n");
+};
+
+const main = (): void => {
+  console.log("\n");
+  console.log("####################################################");
+  console.log("# ポーカー診断シミュレーション (10 サンプルパターン)  #");
+  console.log("####################################################");
+  console.log(
+    `\n判定軸: VPIP >= ${VPIP_THRESHOLD}% で Loose / AF >= ${AF_THRESHOLD.toFixed(1)} で Aggressive\n`
+  );
+
+  let mismatchCount = 0;
+  for (const [i, scenario] of SCENARIOS.entries()) {
+    console.log(renderScenario(scenario, i));
+    const stats = calculatePokerStats(HERO_ID, scenario.hands);
+    if (determinePokerStyle(stats) !== scenario.expectedStyle) {
+      mismatchCount++;
+    }
+  }
+
+  console.log("\n");
+  console.log("=".repeat(78));
+  console.log("サマリー");
+  console.log("=".repeat(78));
+  console.log(`総シナリオ数        : ${SCENARIOS.length}`);
+  console.log(`期待スタイル一致数  : ${SCENARIOS.length - mismatchCount}`);
+  console.log(`想定外スタイル発生  : ${mismatchCount}`);
+  console.log("");
+
+  if (mismatchCount > 0) {
+    process.exitCode = 1;
+  }
+};
+
+main();

--- a/src/simulations/scenarios.ts
+++ b/src/simulations/scenarios.ts
@@ -1,0 +1,395 @@
+import type { Action, ActionType, Card, Hand, PokerStyle } from "@/types";
+import { BUSINESS_TYPE_MAP } from "@/constants/diagnosis";
+
+export const HERO_ID = "hero";
+export const VILLAIN_ID = "villain";
+
+const HERO_HOLE: readonly [Card, Card] = [
+  { suit: "spade", rank: "A" },
+  { suit: "heart", rank: "K" },
+];
+
+const BOARD_FULL: readonly Card[] = [
+  { suit: "diamond", rank: "Q" },
+  { suit: "club", rank: "J" },
+  { suit: "heart", rank: "10" },
+  { suit: "spade", rank: "9" },
+  { suit: "diamond", rank: "8" },
+];
+
+type Street = "preflop" | "flop" | "turn" | "river";
+
+type Move = { readonly action: ActionType; readonly amount: number | null };
+
+export type HandSpec = {
+  readonly preflop: Move;
+  readonly flop?: Move;
+  readonly turn?: Move;
+  readonly river?: Move;
+};
+
+const DEFAULT_AMOUNTS: Readonly<Record<Street, number>> = {
+  preflop: 6,
+  flop: 12,
+  turn: 25,
+  river: 50,
+};
+
+const toMove = (action: ActionType, street: Street): Move => ({
+  action,
+  amount: action === "raise" ? DEFAULT_AMOUNTS[street] : null,
+});
+
+// 短縮ヘルパー: F("raise","raise","call","raise") のように1〜4要素で書ける
+// 省略すると hero がそのストリートに到達していない（fold済 or showdown未達）扱い
+export const F = (
+  pf: ActionType,
+  fl?: ActionType,
+  tn?: ActionType,
+  rv?: ActionType
+): HandSpec => ({
+  preflop: toMove(pf, "preflop"),
+  ...(fl ? { flop: toMove(fl, "flop") } : {}),
+  ...(tn ? { turn: toMove(tn, "turn") } : {}),
+  ...(rv ? { river: toMove(rv, "river") } : {}),
+});
+
+const buildHand = (handNumber: number, spec: HandSpec): Hand => {
+  const actions: Action[] = [];
+  let order = 0;
+  let lastStreet: Street = "preflop";
+
+  const phases: ReadonlyArray<readonly [Street, Move | undefined]> = [
+    ["preflop", spec.preflop],
+    ["flop", spec.flop],
+    ["turn", spec.turn],
+    ["river", spec.river],
+  ];
+
+  for (const [street, move] of phases) {
+    if (!move) break;
+    lastStreet = street;
+    actions.push({
+      playerId: HERO_ID,
+      type: move.action,
+      amount: move.amount,
+      street,
+      order: order++,
+    });
+    if (move.action === "fold") break;
+    // 対戦相手はヒーローのアクションに対応してコール（pot構築用、統計には影響しない）
+    actions.push({
+      playerId: VILLAIN_ID,
+      type: "call",
+      amount: move.amount,
+      street,
+      order: order++,
+    });
+  }
+
+  const heroFolded = actions.some(
+    (a) => a.playerId === HERO_ID && a.type === "fold"
+  );
+
+  const board =
+    lastStreet === "river"
+      ? BOARD_FULL
+      : lastStreet === "turn"
+        ? BOARD_FULL.slice(0, 4)
+        : lastStreet === "flop"
+          ? BOARD_FULL.slice(0, 3)
+          : [];
+
+  return {
+    id: `hand-${handNumber}`,
+    handNumber,
+    buttonPlayerId: VILLAIN_ID,
+    communityCards: board,
+    playerHands: [
+      { playerId: HERO_ID, holeCards: HERO_HOLE },
+      { playerId: VILLAIN_ID, holeCards: null },
+    ],
+    actions,
+    pot: 0,
+    currentStreet: lastStreet,
+    isComplete: heroFolded || lastStreet === "river",
+  };
+};
+
+export type Scenario = {
+  readonly id: string;
+  readonly playerName: string;
+  readonly persona: string;
+  readonly summary: string;
+  readonly expectedStyle: PokerStyle;
+  readonly hands: readonly Hand[];
+};
+
+const makeScenario = (params: {
+  readonly id: string;
+  readonly playerName: string;
+  readonly persona: string;
+  readonly summary: string;
+  readonly expectedStyle: PokerStyle;
+  readonly handSpecs: readonly HandSpec[];
+}): Scenario => ({
+  id: params.id,
+  playerName: params.playerName,
+  persona: params.persona,
+  summary: params.summary,
+  expectedStyle: params.expectedStyle,
+  hands: params.handSpecs.map((spec, i) => buildHand(i + 1, spec)),
+});
+
+export const expectedBusinessTypeOf = (style: PokerStyle): string =>
+  BUSINESS_TYPE_MAP[style].name;
+
+// =====================================================================
+// 10 シナリオ定義
+// 各シナリオは 12 ハンド構成で、想定スタイル判定が確実に決まるように
+// 配分（PF raise/call/fold の比率と postflop の raise/call バランス）を調整
+// =====================================================================
+
+export const SCENARIOS: readonly Scenario[] = [
+  // -------------------------------------------------------------------
+  // ループアグレッシブ（革新的開拓者タイプ）×3
+  // -------------------------------------------------------------------
+  makeScenario({
+    id: "lag-1",
+    playerName: "鈴木 大輔",
+    persona: "攻めの新規事業リーダー",
+    summary:
+      "ほぼ全てのハンドに参戦し、強気にレイズで主導権を握り続ける。撤退判断も速く、不利と見るや躊躇なく次へ向かう。",
+    expectedStyle: "loose-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "call", "raise"),
+      F("raise", "call", "call", "raise"),
+      F("raise", "raise", "call", "call"),
+      F("raise", "raise", "raise"),
+      F("raise", "raise", "fold"),
+      F("raise", "call", "raise", "call"),
+      F("raise", "check", "check", "check"),
+      F("call", "call", "check", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "lag-2",
+    playerName: "高橋 美咲",
+    persona: "直感型スタートアップ創業者",
+    summary:
+      "勘とスピード重視で参加判断を下し、ベットで相手にプレッシャーをかけ続ける。完璧な情報を待たず、自ら状況を作り出す。",
+    expectedStyle: "loose-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "call", "raise"),
+      F("raise", "raise", "raise"),
+      F("raise", "raise", "fold"),
+      F("raise", "call", "check", "raise"),
+      F("raise", "raise", "check", "check"),
+      F("call", "raise", "call", "fold"),
+      F("call", "check", "check", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "lag-3",
+    playerName: "佐々木 健",
+    persona: "強気のセールス・ハンター",
+    summary:
+      "圧倒的な行動量で全ての商談に首を突っ込み、押しの一手で契約を取りに行く。負けが見えたハンドの撤退も鮮やかでロスを最小化。",
+    expectedStyle: "loose-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "raise", "call"),
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "call", "raise"),
+      F("raise", "raise", "raise"),
+      F("raise", "raise", "raise", "fold"),
+      F("raise", "raise", "fold"),
+      F("raise", "call", "raise", "call"),
+      F("raise", "check", "check", "check"),
+      F("call", "call", "check", "check"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  // -------------------------------------------------------------------
+  // タイトアグレッシブ（戦略的リーダータイプ）×3
+  // -------------------------------------------------------------------
+  makeScenario({
+    id: "tag-1",
+    playerName: "中村 俊介",
+    persona: "切れ味鋭い戦略コンサルタント",
+    summary:
+      "参加するハンドを厳選し、勝てる場面でだけ強くベットを打ち抜く。アクション時はほぼ常にレイズで、選択と集中を体現するスタイル。",
+    expectedStyle: "tight-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "raise", "call"),
+      F("raise", "raise", "raise", "raise"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "tag-2",
+    playerName: "渡辺 真理子",
+    persona: "投資判断のプロジェクト責任者",
+    summary:
+      "見送りの決断ができる慎重さと、ここぞという場面で大胆に資源を投下する判断力を併せ持つ。レンジは狭いが各ハンドへのコミットは深い。",
+    expectedStyle: "tight-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "call"),
+      F("raise", "raise", "call", "raise"),
+      F("raise", "raise", "raise"),
+      F("call", "call", "fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "tag-3",
+    playerName: "山田 哲也",
+    persona: "厳選・集中型の財務責任者（CFO）",
+    summary:
+      "勝率の高いハンドだけに資本を投下し、参戦したら一気にレイズで攻める。極度に絞ったレンジで質の高いリターンを狙う典型的TAG。",
+    expectedStyle: "tight-aggressive",
+    handSpecs: [
+      F("raise", "raise", "raise", "raise"),
+      F("raise", "raise", "raise"),
+      F("call", "raise", "raise", "raise"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  // -------------------------------------------------------------------
+  // ルースパッシブ（協調的サポータータイプ）×2
+  // -------------------------------------------------------------------
+  makeScenario({
+    id: "lp-1",
+    playerName: "小林 由紀子",
+    persona: "場を盛り上げるチームサポーター",
+    summary:
+      "ほとんどのハンドに付き合い、相手のベットには気持ちよくコールで応じる。場を壊さない柔らかい振る舞いで参加メンバーを和ませる。",
+    expectedStyle: "loose-passive",
+    handSpecs: [
+      F("call", "call", "call", "call"),
+      F("call", "call", "call", "check"),
+      F("call", "call", "check", "call"),
+      F("raise", "call", "call", "call"),
+      F("call", "check", "call", "check"),
+      F("call", "call", "fold"),
+      F("call", "call", "check", "check"),
+      F("call", "check", "check", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "lp-2",
+    playerName: "森田 健介",
+    persona: "共感型のチームリーダー",
+    summary:
+      "幅広い案件に関与しつつ、強引な主張は避けて相手のペースに合わせる。たまに自分から動くこともあるが、基本は調整役に徹する。",
+    expectedStyle: "loose-passive",
+    handSpecs: [
+      F("raise", "call", "call", "call"),
+      F("call", "call", "call", "check"),
+      F("call", "call", "check", "call"),
+      F("raise", "call", "check", "check"),
+      F("call", "call", "fold"),
+      F("call", "check", "call", "check"),
+      F("call", "check", "check", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  // -------------------------------------------------------------------
+  // タイトパッシブ（堅実な管理者タイプ）×2
+  // -------------------------------------------------------------------
+  makeScenario({
+    id: "tp-1",
+    playerName: "伊藤 義隆",
+    persona: "リスク回避型の財務管理者",
+    summary:
+      "参加ハンドを極限まで絞り、入った場合もコールやチェックで様子を見ながら堅実に運ぶ。一貫した規律で大きな損失を出さない。",
+    expectedStyle: "tight-passive",
+    handSpecs: [
+      F("raise", "call", "call", "check"),
+      F("call", "check", "call", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+
+  makeScenario({
+    id: "tp-2",
+    playerName: "藤田 由美",
+    persona: "慎重派のオペレーション・マネージャー",
+    summary:
+      "参加判断は厳しめで、リスクの高いハンドは即撤退。入ったハンドでも控えめに動き、確実な状況以外で大きく賭けない安定志向。",
+    expectedStyle: "tight-passive",
+    handSpecs: [
+      F("raise", "call", "check", "check"),
+      F("call", "call", "check", "call"),
+      F("raise", "check", "check", "check"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+      F("fold"),
+    ],
+  }),
+];

--- a/src/simulations/types.ts
+++ b/src/simulations/types.ts
@@ -1,0 +1,16 @@
+import type { DiagnosisResult, Hand, Player, PokerStyle } from "@/types";
+
+export type SampleScenarioMeta = {
+  readonly id: string;
+  readonly playerName: string;
+  readonly persona: string;
+  readonly summary: string;
+  readonly expectedStyle: PokerStyle;
+};
+
+export type SampleResult = {
+  readonly scenario: SampleScenarioMeta;
+  readonly diagnosis: DiagnosisResult;
+  readonly hands: readonly Hand[];
+  readonly players: readonly Player[];
+};


### PR DESCRIPTION
## Summary
- ポーカー診断ロジックのアウトプットを体感できる **架空プレイヤー10人分のサンプル** を追加
- 4スタイル × 想定ペルソナ別に構成（LAG×3 / TAG×3 / LP×2 / TP×2）
- 各サンプルは「12ハンドのプレイ履歴 → 統計算出 → スタイル判定 → 既存 OpenAI 診断ロジックを通したAI診断結果」をフルセットで保持
- システム内で確認できる導入企業向けの閲覧ページ \`/samples\` を新設（既存 result 画面 UI を流用）

## 何を追加したか

### シミュレーションデータ層 — \`src/simulations/\`
| ファイル | 役割 |
|---|---|
| \`scenarios.ts\` | 10ペルソナの架空プレイ履歴（各12ハンド）と期待スタイルを定義 |
| \`runner.ts\` | コンソールで統計＋判定レポートを出力（OpenAI不使用） |
| \`diagnose.ts\` | 既存 \`generateDiagnosis\` で AI 診断を呼び出し、結果を \`results/data.json\` に書き出し |
| \`results/data.json\` | 生成済みの全10件 AI 診断結果 |
| \`results/index.ts\` / \`types.ts\` | JSON ローダーと \`SampleResult\` 型 |

### 閲覧 UI — \`src/app/samples/\`
| ルート | 内容 |
|---|---|
| \`/samples\` | 10カードの一覧。スタイルバッジ・ペルソナ・主要統計をプレビュー |
| \`/samples/[id]\` | 既存 \`DiagnosisCard\` / \`RadarChartDisplay\` / \`StatsSummary\` / \`PlayerPlayReview\` / \`AdviceSection\` を流用した詳細ページ。\`generateStaticParams\` で全10URLを静的生成 |

### スクリプト
\`\`\`bash
npm run simulate          # コンソールで統計→判定レポートを確認（OpenAI不要）
npm run simulate:diagnose # OpenAI を呼んで data.json を再生成
\`\`\`

## 10パターン一覧

| ID | ペルソナ | スタイル | ビジネスタイプ |
|---|---|---|---|
| lag-1 | 攻めの新規事業リーダー | LAG | 革新的開拓者 |
| lag-2 | 直感型スタートアップ創業者 | LAG | 革新的開拓者 |
| lag-3 | 強気のセールス・ハンター | LAG | 革新的開拓者 |
| tag-1 | 切れ味鋭い戦略コンサルタント | TAG | 戦略的リーダー |
| tag-2 | 投資判断のプロジェクト責任者 | TAG | 戦略的リーダー |
| tag-3 | 厳選・集中型のCFO | TAG | 戦略的リーダー |
| lp-1 | 場を盛り上げるサポーター | LP | 協調的サポーター |
| lp-2 | 共感型のチームリーダー | LP | 協調的サポーター |
| tp-1 | リスク回避型の財務管理者 | TP | 堅実な管理者 |
| tp-2 | 慎重派のオペレーション・マネージャー | TP | 堅実な管理者 |

統計はすべて期待スタイルに収束することを実コードの \`calculatePokerStats\` / \`determinePokerStyle\` で検証済み（10/10 一致）。

## Test plan
- [x] \`npx tsc --noEmit\` — 型エラー無し
- [x] \`npm run build\` — 静的生成 \`/samples/lag-1\` 〜 \`/samples/tp-2\` を含めて成功
- [x] \`npm run simulate\` — 全10シナリオが期待スタイルと一致（10/10 OK）
- [x] \`npm run simulate:diagnose\` — OpenAI から全10件の axes(6軸) / advice / strengths / growthPotentials を取得し \`data.json\` に保存
- [x] \`/samples\` 一覧ページのカード表示確認（Playwright スナップショット）
- [x] \`/samples/lag-1\` 詳細ページ：DiagnosisCard / レーダーチャート / 統計サマリー / 12ハンドのプレイ振り返り / AIアドバイス すべて表示確認

## 補足
- \`tsx\` を devDep に追加（\`--env-file=.env.local\` で API キー読み込みのため）
- AI 診断は固定 JSON として保存しているので、ページ閲覧時に毎回 OpenAI を叩かない（コスト・速度面で導入企業デモに適切）
- 再生成したい場合のみ \`npm run simulate:diagnose\` を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)